### PR TITLE
Add a Utility to Extract a Molecules Conformers

### DIFF
--- a/openff/recharge/tests/utilities/test_openeye.py
+++ b/openff/recharge/tests/utilities/test_openeye.py
@@ -1,10 +1,16 @@
+import numpy
 import pytest
 
+from openff.recharge.conformers.conformers import OmegaELF10
 from openff.recharge.utilities.exceptions import (
     InvalidSmirksError,
     MoleculeFromSmilesError,
 )
-from openff.recharge.utilities.openeye import match_smirks, smiles_to_molecule
+from openff.recharge.utilities.openeye import (
+    match_smirks,
+    molecule_to_conformers,
+    smiles_to_molecule,
+)
 
 
 def test_smiles_to_molecule():
@@ -48,3 +54,16 @@ def test_match_smirks_invalid():
         match_smirks("X", smiles_to_molecule("C"))
 
     assert error_info.value.smirks == "X"
+
+
+def test_molecule_to_conformer():
+    """Test that the `molecule_to_conformers` function returns
+    a non-zero numpy array of the correct shape."""
+
+    oe_molecule = OmegaELF10.generate(smiles_to_molecule("CO"), 1)
+    conformers = molecule_to_conformers(oe_molecule)
+
+    assert len(conformers) == 1
+    assert conformers[0].shape == (6, 3)
+
+    assert not numpy.allclose(conformers[0], 0.0)

--- a/openff/recharge/utilities/openeye.py
+++ b/openff/recharge/utilities/openeye.py
@@ -3,6 +3,7 @@ import logging
 import re
 from typing import Any, Callable, Dict, List, Type, TypeVar
 
+import numpy
 from openeye import oechem
 
 from openff.recharge.utilities.exceptions import (
@@ -150,3 +151,32 @@ def match_smirks(
         matches.append(matched_indices)
 
     return matches
+
+
+def molecule_to_conformers(oe_molecule: oechem.OEMol) -> List[numpy.ndarray]:
+    """Extracts the conformers of a molecule and stores them
+    inside of a numpy array.
+
+    Parameters
+    ----------
+    oe_molecule
+        The molecule to extract the conformers from.
+
+    Returns
+    -------
+        A list of the extracted conformers, where each
+        conformer is a numpy array with shape=(n_atoms, 3).
+    """
+
+    conformers = []
+
+    for oe_conformer in oe_molecule.GetConfs():
+
+        conformer = numpy.zeros((oe_molecule.NumAtoms(), 3))
+
+        for atom_index, coordinates in oe_conformer.GetCoords().items():
+            conformer[atom_index, :] = coordinates
+
+        conformers.append(conformer)
+
+    return conformers


### PR DESCRIPTION
## Description
This PR adds a new `molecule_to_conformers` utility which extracts a molecules conformers and stores them in `numpy` arrays.

## Status
- [X] Ready to go