### PR TITLE
Add Electrostatic Potential Base Classes

### DIFF
--- a/openff/recharge/esp/__init__.py
+++ b/openff/recharge/esp/__init__.py
@@ -1,0 +1,3 @@
+from openff.recharge.esp.esp import ESPGenerator, ESPSettings
+
+__all__ = [ESPGenerator, ESPSettings]

--- a/openff/recharge/esp/esp.py
+++ b/openff/recharge/esp/esp.py
@@ -1,0 +1,106 @@
+import abc
+from typing import List, Tuple
+
+import numpy
+from openeye.oechem import OEMol
+from pydantic import BaseModel, Field
+
+from openff.recharge.grids import GridGenerator, GridSettings
+from openff.recharge.utilities.exceptions import MissingConformersError
+from openff.recharge.utilities.openeye import molecule_to_conformers
+
+
+class ESPSettings(BaseModel):
+    """A class which contains the settings to use in an ESP calculation.
+    """
+
+    basis: str = Field(
+        "6-31g*", description="The basis set to use in the ESP calculation."
+    )
+    method: str = Field("hf", description="The method to use in the ESP calculation.")
+
+    grid_settings: GridSettings = Field(
+        ...,
+        description="The settings to use when generating the grid to generate the "
+        "electrostatic potential on.",
+    )
+
+
+class ESPGenerator(abc.ABC):
+    """A base class for classes which are able to generate the electrostatic
+    potential of a molecule on a specified grid.
+    """
+
+    @classmethod
+    @abc.abstractmethod
+    def _generate(
+        cls,
+        oe_molecule: OEMol,
+        conformer: numpy.ndarray,
+        grid: numpy.ndarray,
+        settings: ESPSettings,
+        directory: str = None,
+    ) -> numpy.ndarray:
+        """The implementation of the public ``generate`` function which
+        should return the ESP for the provided conformer.
+
+        Parameters
+        ----------
+        oe_molecule
+            The molecule to generate the ESP for.
+        conformer
+            The conformer of the molecule to generate the ESP for.
+        grid
+            The grid to generate the ESP on with shape=(n_grid_points, 3).
+        settings
+            The settings to use when generating the ESP.
+        directory
+            The directory to run the calculation in. If none is specified,
+            a temporary directory will be created and used.
+
+        Returns
+        -------
+            The ESP at each grid point with shape=(n_grid_points, 1).
+        """
+
+    @classmethod
+    def generate(
+        cls, oe_molecule: OEMol, settings: ESPSettings, directory: str = None
+    ) -> List[Tuple[numpy.ndarray, numpy.ndarray]]:
+        """Generate the electrostatic potential (ESP) on a grid defined by
+        a provided set of settings.
+
+        Parameters
+        ----------
+        oe_molecule
+            The molecule to generate the ESP for.
+        settings
+            The settings to use when generating the ESP.
+        directory
+            The directory to run the calculation in. If none is specified,
+            a temporary directory will be created and used.
+
+        Returns
+        -------
+            The grid which the ESP was generated on with shape=(n_grid_points, 3)
+            and the ESP at each grid point with shape=(n_grid_points, 1) for each
+            conformer present on the specified molecule.
+        """
+
+        if oe_molecule.NumConfs() == 0:
+            raise MissingConformersError()
+
+        conformers = molecule_to_conformers(oe_molecule)
+
+        values = []
+
+        for conformer in conformers:
+
+            grid = GridGenerator.generate(
+                oe_molecule, conformer, settings.grid_settings
+            )
+            esp = cls._generate(oe_molecule, conformer, grid, settings, directory)
+
+            values.append((grid, esp))
+
+        return values

--- a/openff/recharge/generators/bcc.py
+++ b/openff/recharge/generators/bcc.py
@@ -11,12 +11,12 @@ from openeye import oechem, oequacpac
 
 from openff.recharge.conformers.conformers import ConformerGenerator
 from openff.recharge.generators.exceptions import (
-    MissingConformersError,
     OEQuacpacError,
     UnableToAssignChargeError,
 )
 from openff.recharge.models import BondChargeCorrection
 from openff.recharge.utilities import get_data_file_path
+from openff.recharge.utilities.exceptions import MissingConformersError
 from openff.recharge.utilities.openeye import call_openeye, match_smirks
 
 

--- a/openff/recharge/generators/exceptions.py
+++ b/openff/recharge/generators/exceptions.py
@@ -7,16 +7,6 @@ class OEQuacpacError(RechargeException):
     """An exception raised when Quacpac fails to complete successfully."""
 
 
-class MissingConformersError(RechargeException):
-    """An exception raised when a molecule which does not contain any conformers
-    was provided to a function which required them."""
-
-    def __init__(self):
-        super(MissingConformersError, self).__init__(
-            "The provided molecule does not contain any conformers."
-        )
-
-
 class UnableToAssignChargeError(RechargeException):
     """An exception raised when atoms in a molecule could not correctly be
     assigned a partial charge."""

--- a/openff/recharge/tests/charging/test_bcc.py
+++ b/openff/recharge/tests/charging/test_bcc.py
@@ -5,10 +5,10 @@ from openeye import oechem, oequacpac
 from openff.recharge.conformers.conformers import OmegaELF10
 from openff.recharge.generators.bcc import AM1BCC
 from openff.recharge.generators.exceptions import (
-    MissingConformersError,
     OEQuacpacError,
     UnableToAssignChargeError,
 )
+from openff.recharge.utilities.exceptions import MissingConformersError
 from openff.recharge.utilities.openeye import call_openeye, smiles_to_molecule
 
 

--- a/openff/recharge/tests/esp/test_esp.py
+++ b/openff/recharge/tests/esp/test_esp.py
@@ -1,0 +1,20 @@
+import pytest
+
+from openff.recharge.esp import ESPGenerator, ESPSettings
+from openff.recharge.grids import GridSettings
+from openff.recharge.utilities.exceptions import MissingConformersError
+from openff.recharge.utilities.openeye import smiles_to_molecule
+
+
+def test_generate_missing_conformers():
+    """Test that the right error is raised when conformers are missing."""
+
+    # Define the settings to use.
+    settings = ESPSettings(grid_settings=GridSettings(spacing=2.0))
+
+    # Generate a small molecule which should finish fast.
+    oe_molecule = smiles_to_molecule("C")
+    oe_molecule.DeleteConfs()
+
+    with pytest.raises(MissingConformersError):
+        ESPGenerator.generate(oe_molecule, settings)

--- a/openff/recharge/utilities/exceptions.py
+++ b/openff/recharge/utilities/exceptions.py
@@ -22,6 +22,16 @@ class MoleculeFromSmilesError(RechargeException):
         self.smiles = smiles
 
 
+class MissingConformersError(RechargeException):
+    """An exception raised when a molecule which does not contain any conformers
+    was provided to a function which required them."""
+
+    def __init__(self):
+        super(MissingConformersError, self).__init__(
+            "The provided molecule does not contain any conformers."
+        )
+
+
 class InvalidSmirksError(RechargeException):
     """An exception raised when an invalid smirks pattern is provided."""
 


### PR DESCRIPTION
## Description
This PR adds the base classes for those classes which will compute the electrostatic potentials (ESPs) of molecules using a specific frameworks (e.g. Psi4).

## Status
- [X] Ready to go