### PR TITLE
Install the CI package using setup.py instead of Pip

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Package
         shell: bash -l {0}
         run: |
-          python -m pip install . --no-deps
+          python setup.py develop --no-deps
 
       - name: Run Tests
         shell: bash -l {0}


### PR DESCRIPTION
## Description
This PR updates the CI to install the package using `setup.py` instead of `pip` before the tests are run. This is change is made in attempt to fix `codecov`.

## Status
- [x] Ready to go