### PR TITLE
Fix AM1BCC Aromaticity Model for Acenaphthene

### DIFF
--- a/openff/recharge/charges/bcc.py
+++ b/openff/recharge/charges/bcc.py
@@ -111,20 +111,35 @@ class AromaticityModel:
 
         cls._set_aromatic(case_1_atoms, oe_molecule)
 
+        # Track the ar6 assignments as there is no atom attribute to
+        # safely determine if an atom is in a six member ring when
+        # that same atom is also in a five member ring.
+        ar6_assignments = {*case_1_atoms}
+
         # Case 2)
         case_2_smirks = (
             f"{x_type.replace('N', '1')}1"
             f"=@{x_type.replace('N', '2')}"
             f"-@{x_type.replace('N', '3')}"
             f"=@{x_type.replace('N', '4')}"
-            f"-@[#6ar6:5]"
-            f":@[#6ar6:6]-@1"
+            f"-@[#6a:5]"
+            f":@[#6a:6]-@1"
         )
 
         case_2_matches = match_smirks(case_2_smirks, oe_molecule, unique=True)
+
+        # Enforce the ar6 condition
+        case_2_matches = [
+            case_2_match
+            for case_2_match in case_2_matches
+            if case_2_match[4] in ar6_assignments and case_2_match[5] in ar6_assignments
+        ]
+
         case_2_atoms = {
             match for matches in case_2_matches for match in matches.values()
         }
+
+        ar6_assignments.update(case_2_atoms)
 
         cls._set_aromatic(case_2_atoms, oe_molecule)
 
@@ -132,22 +147,35 @@ class AromaticityModel:
         case_3_smirks = (
             f"{x_type.replace('N', '1')}1"
             f"=@{x_type.replace('N', '2')}"
-            f"-@[#6ar6:3]"
-            f":@[#6ar6:4]"
-            f":@[#6ar6:5]"
-            f":@[#6ar6:6]-@1"
+            f"-@[#6a:3]"
+            f":@[#6a:4]"
+            f":@[#6a:5]"
+            f":@[#6a:6]-@1"
         )
 
         case_3_matches = match_smirks(case_3_smirks, oe_molecule, unique=True)
+
+        # Enforce the ar6 condition
+        case_3_matches = [
+            case_3_match
+            for case_3_match in case_3_matches
+            if case_3_match[2] in ar6_assignments
+            and case_3_match[3] in ar6_assignments
+            and case_3_match[4] in ar6_assignments
+            and case_3_match[5] in ar6_assignments
+        ]
+
         case_3_atoms = {
             match for matches in case_3_matches for match in matches.values()
         }
+
+        ar6_assignments.update(case_3_atoms)
 
         cls._set_aromatic(case_3_atoms, oe_molecule)
 
         # Case 4)
         case_4_smirks = (
-            "[#6+1r7:1]1"
+            "[#6+1:1]1"
             f"-@{x_type.replace('N', '2')}"
             f"=@{x_type.replace('N', '3')}"
             f"-@{x_type.replace('N', '4')}"
@@ -273,7 +301,7 @@ class BCCGenerator:
         """
 
         # Check for unassigned atoms
-        unassigned_atoms = numpy.where(~assignment_matrix.any(axis=1))[0]
+        unassigned_atoms = numpy.where(~bcc_counts_matrix.any(axis=1))[0]
 
         if len(unassigned_atoms) > 0:
             unassigned_atom_string = ", ".join(map(str, unassigned_atoms))

--- a/openff/recharge/tests/charges/test_bcc.py
+++ b/openff/recharge/tests/charges/test_bcc.py
@@ -2,6 +2,8 @@ import numpy
 import pytest
 
 from openff.recharge.charges.bcc import (
+    AromaticityModel,
+    AromaticityModels,
     BCCGenerator,
     BCCSettings,
     BondChargeCorrection,
@@ -140,4 +142,73 @@ def test_am1_bcc_missing_parameters(bond_charge_corrections):
 
     assert "could not be assigned a bond charge correction atom type" in str(
         error_info.value
+    )
+
+
+def test_am1_bcc_aromaticity():
+    """Checks that the custom AM1BCC aromaticity model behaves as
+    expected.
+    """
+
+    # Test case 1.
+    oe_molecule = smiles_to_molecule("c1ccccc1")
+    AromaticityModel.assign(oe_molecule, AromaticityModels.AM1BCC)
+
+    assert all(
+        atom.IsAromatic() for atom in oe_molecule.GetAtoms() if atom.GetAtomicNum() == 6
+    )
+    assert all(
+        bond.IsAromatic()
+        for bond in oe_molecule.GetBonds()
+        if bond.GetBgn().GetAtomicNum() == 6 and bond.GetEnd().GetAtomicNum() == 6
+    )
+
+    # Test case 2.
+
+    # Test the easy case of napthelene.
+    oe_molecule = smiles_to_molecule("c1ccc2ccccc2c1")
+    AromaticityModel.assign(oe_molecule, AromaticityModels.AM1BCC)
+
+    assert all(
+        atom.IsAromatic() for atom in oe_molecule.GetAtoms() if atom.GetAtomicNum() == 6
+    )
+    assert all(
+        bond.IsAromatic()
+        for bond in oe_molecule.GetBonds()
+        if bond.GetBgn().GetAtomicNum() == 6 and bond.GetEnd().GetAtomicNum() == 6
+    )
+
+    # Test the tricker case of acenaphthene.
+    oe_molecule = smiles_to_molecule("C1CC2=CC=CC3=C2C1=CC=C3")
+    AromaticityModel.assign(oe_molecule, AromaticityModels.AM1BCC)
+
+    atoms = {atom.GetIdx(): atom for atom in oe_molecule.GetAtoms()}
+
+    assert [not atoms[index].IsAromatic() for index in range(2)]
+    assert [atoms[index].IsAromatic() for index in range(2, 12)]
+
+    # Test case 4.
+    oe_molecule = smiles_to_molecule("[C+]1C=CC=CC=C1")
+    AromaticityModel.assign(oe_molecule, AromaticityModels.AM1BCC)
+
+    assert all(
+        atom.IsAromatic() for atom in oe_molecule.GetAtoms() if atom.GetAtomicNum() == 6
+    )
+    assert all(
+        bond.IsAromatic()
+        for bond in oe_molecule.GetBonds()
+        if bond.GetBgn().GetAtomicNum() == 6 and bond.GetEnd().GetAtomicNum() == 6
+    )
+
+    # Test case 5.
+    oe_molecule = smiles_to_molecule("o1cccc1")
+    AromaticityModel.assign(oe_molecule, AromaticityModels.AM1BCC)
+
+    assert all(
+        atom.IsAromatic() for atom in oe_molecule.GetAtoms() if atom.GetAtomicNum() == 6
+    )
+    assert all(
+        bond.IsAromatic()
+        for bond in oe_molecule.GetBonds()
+        if bond.GetBgn().GetAtomicNum() == 6 and bond.GetEnd().GetAtomicNum() == 6
     )


### PR DESCRIPTION
## Description
This PR fixes a bug whereby the smirks patterns to detect cases two and three of the model made use of the `r` atom attribute to detect atoms in a six membered ring. This failed however for atoms which are in both six and five member rings and the `r` attribute only detects the size of the smallest ring.

## Status
- [X] Ready to go