### PR TITLE
Fix AM1BCC Aromaticity for Fused Aromatic Rings

### DIFF
--- a/openff/recharge/tests/charges/test_bcc.py
+++ b/openff/recharge/tests/charges/test_bcc.py
@@ -1,5 +1,6 @@
 import numpy
 import pytest
+from openeye import oechem
 
 from openff.recharge.charges.bcc import (
     AromaticityModel,
@@ -101,40 +102,45 @@ def test_am1_bcc_missing_parameters():
     )
 
 
-def test_am1_bcc_aromaticity():
+@pytest.mark.parametrize(
+    "smiles",
+    [
+        "c1ccccc1",  # benzene
+        "c1ccc2ccccc2c1",  # napthelene
+        "c1ccc2c(c1)ccc3ccccc23",  # phenanthrene
+        "c1ccc2c(c1)ccc3c4ccccc4ccc23",  # chrysene
+        "c1cc2ccc3cccc4ccc(c1)c2c34",  # pyrene
+        "c1cc2ccc3ccc4ccc5ccc6ccc1c7c2c3c4c5c67",  # coronene
+        "Cc1ccc2cc3ccc(C)cc3cc2c1",  # 2,7-Dimethylanthracene
+    ],
+)
+def test_am1_bcc_aromaticity_simple(smiles):
     """Checks that the custom AM1BCC aromaticity model behaves as
-    expected.
+    expected for simple fused hydrocarbons.
     """
 
-    # Test case 1.
-    oe_molecule = smiles_to_molecule("c1ccccc1")
+    oe_molecule = smiles_to_molecule(smiles)
     AromaticityModel.assign(oe_molecule, AromaticityModels.AM1BCC)
 
-    assert all(
-        atom.IsAromatic() for atom in oe_molecule.GetAtoms() if atom.GetAtomicNum() == 6
-    )
+    ring_carbons = [
+        atom
+        for atom in oe_molecule.GetAtoms()
+        if atom.GetAtomicNum() == 6 and oechem.OEAtomIsInRingSize(atom, 6)
+    ]
+    ring_indices = {atom.GetIdx() for atom in ring_carbons}
+
+    assert all(atom.IsAromatic() for atom in ring_carbons)
     assert all(
         bond.IsAromatic()
         for bond in oe_molecule.GetBonds()
-        if bond.GetBgn().GetAtomicNum() == 6 and bond.GetEnd().GetAtomicNum() == 6
+        if bond.GetBgnIdx() in ring_indices and bond.GetEndIdx() in ring_indices
     )
 
-    # Test case 2.
 
-    # Test the easy case of napthelene.
-    oe_molecule = smiles_to_molecule("c1ccc2ccccc2c1")
-    AromaticityModel.assign(oe_molecule, AromaticityModels.AM1BCC)
+def test_am1_bcc_aromaticity_ring_size():
+    """Checks that the custom AM1BCC aromaticity model behaves as
+    expected fused hydrocarbons with varying ring sizes"""
 
-    assert all(
-        atom.IsAromatic() for atom in oe_molecule.GetAtoms() if atom.GetAtomicNum() == 6
-    )
-    assert all(
-        bond.IsAromatic()
-        for bond in oe_molecule.GetBonds()
-        if bond.GetBgn().GetAtomicNum() == 6 and bond.GetEnd().GetAtomicNum() == 6
-    )
-
-    # Test the tricker case of acenaphthene.
     oe_molecule = smiles_to_molecule("C1CC2=CC=CC3=C2C1=CC=C3")
     AromaticityModel.assign(oe_molecule, AromaticityModels.AM1BCC)
 
@@ -142,32 +148,6 @@ def test_am1_bcc_aromaticity():
 
     assert [not atoms[index].IsAromatic() for index in range(2)]
     assert [atoms[index].IsAromatic() for index in range(2, 12)]
-
-    # Test case 4.
-    oe_molecule = smiles_to_molecule("[C+]1C=CC=CC=C1")
-    AromaticityModel.assign(oe_molecule, AromaticityModels.AM1BCC)
-
-    assert all(
-        atom.IsAromatic() for atom in oe_molecule.GetAtoms() if atom.GetAtomicNum() == 6
-    )
-    assert all(
-        bond.IsAromatic()
-        for bond in oe_molecule.GetBonds()
-        if bond.GetBgn().GetAtomicNum() == 6 and bond.GetEnd().GetAtomicNum() == 6
-    )
-
-    # Test case 5.
-    oe_molecule = smiles_to_molecule("o1cccc1")
-    AromaticityModel.assign(oe_molecule, AromaticityModels.AM1BCC)
-
-    assert all(
-        atom.IsAromatic() for atom in oe_molecule.GetAtoms() if atom.GetAtomicNum() == 6
-    )
-    assert all(
-        bond.IsAromatic()
-        for bond in oe_molecule.GetBonds()
-        if bond.GetBgn().GetAtomicNum() == 6 and bond.GetEnd().GetAtomicNum() == 6
-    )
 
 
 def test_generate():


### PR DESCRIPTION
## Description
This PR fixes edge cases in the AM1BCC aromaticity model whereby cases 2) and 3) should be applied self consistently to ensure that the aromaticity checks properly propagate down chained fused aromatic rings such as in the case of 2,7-Dimethylanthracene:

<img width="300" alt="2,7-Dimethylanthracene" src="https://user-images.githubusercontent.com/22272126/87231933-53582980-c378-11ea-9f86-4a6cbb013696.png">

## Status
- [X] Ready to go