### PR TITLE
Standardise Syntax of ESPGenerator

### DIFF
--- a/openff/recharge/tests/esp/test_esp.py
+++ b/openff/recharge/tests/esp/test_esp.py
@@ -1,20 +1,21 @@
+import numpy
 import pytest
 
 from openff.recharge.esp import ESPGenerator, ESPSettings
 from openff.recharge.grids import GridSettings
-from openff.recharge.utilities.exceptions import MissingConformersError
 from openff.recharge.utilities.openeye import smiles_to_molecule
 
 
-def test_generate_missing_conformers():
-    """Test that the right error is raised when conformers are missing."""
+def test_abstract_generate():
+    """Test that the right error is raised when attempting to
+    generate an esp using the abstract base class."""
 
     # Define the settings to use.
     settings = ESPSettings(grid_settings=GridSettings(spacing=2.0))
 
     # Generate a small molecule which should finish fast.
     oe_molecule = smiles_to_molecule("C")
-    oe_molecule.DeleteConfs()
+    conformer = numpy.zeros((oe_molecule.NumAtoms(), 3))
 
-    with pytest.raises(MissingConformersError):
-        ESPGenerator.generate(oe_molecule, settings)
+    with pytest.raises(NotImplementedError):
+        ESPGenerator.generate(oe_molecule, conformer, settings)

--- a/openff/recharge/tests/esp/test_psi4.py
+++ b/openff/recharge/tests/esp/test_psi4.py
@@ -1,6 +1,5 @@
 import numpy
 import pytest
-from openeye import oechem
 
 from openff.recharge.esp import ESPSettings
 from openff.recharge.esp.exceptions import Psi4Error
@@ -83,12 +82,7 @@ def test_generate():
         ]
     )
 
-    oe_molecule.NewConf(oechem.OEFloatArray(conformer.flatten()))
-
-    electrostatic_potentials = Psi4ESPGenerator.generate(oe_molecule, settings)
-    assert len(electrostatic_potentials) == 1
-
-    grid, esp = electrostatic_potentials[0]
+    grid, esp = Psi4ESPGenerator.generate(oe_molecule, conformer, settings)
 
     assert len(grid) == len(esp)
     assert len(grid) > 0
@@ -105,12 +99,10 @@ def test_ps4_error():
 
     # Generate a small molecule with an invalid conformer.
     oe_molecule = smiles_to_molecule("C")
-    oe_molecule.DeleteConfs()
     conformer = numpy.zeros((5, 3))
-    oe_molecule.NewConf(oechem.OEFloatArray(conformer.flatten()))
 
     with pytest.raises(Psi4Error) as error_info:
-        Psi4ESPGenerator.generate(oe_molecule, settings)
+        Psi4ESPGenerator.generate(oe_molecule, conformer, settings)
 
     error_message = str(error_info.value)
 

--- a/openff/recharge/utilities/exceptions.py
+++ b/openff/recharge/utilities/exceptions.py
@@ -22,16 +22,6 @@ class MoleculeFromSmilesError(RechargeException):
         self.smiles = smiles
 
 
-class MissingConformersError(RechargeException):
-    """An exception raised when a molecule which does not contain any conformers
-    was provided to a function which required them."""
-
-    def __init__(self):
-        super(MissingConformersError, self).__init__(
-            "The provided molecule does not contain any conformers."
-        )
-
-
 class InvalidSmirksError(RechargeException):
     """An exception raised when an invalid smirks pattern is provided."""
 


### PR DESCRIPTION
## Description
This PR attempts to make the syntax of the `ESPGenerator.generator` function more unified with other similar methods by accepting a conformer as an argument rather than trying to read it off the input molecule.

## Status
- [X] Ready to go