### PR TITLE
Exclude Lines from Codecov Which Shouldn't be Tested

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,13 @@ omit =
     # Omit generated versioneer
     openff/recharge/_version.py
 
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+
 [flake8]
 # Flake8, PyFlakes, etc
 max-line-length = 88


### PR DESCRIPTION
## Description
This PR excludes lines from the codecov report which aren't expected to be tested, for example the type checking statements.

## Status
- [X] Ready to go