### PR TITLE
Adds Utility to Re-order Geometry to Match a Tagged Molecule

### DIFF
--- a/openff/recharge/tests/utilities/test_geometry.py
+++ b/openff/recharge/tests/utilities/test_geometry.py
@@ -1,6 +1,10 @@
 import numpy
 
-from openff.recharge.utilities.geometry import compute_inverse_distance_matrix
+from openff.recharge.utilities.geometry import (
+    compute_inverse_distance_matrix,
+    reorder_conformer,
+)
+from openff.recharge.utilities.openeye import smiles_to_molecule
 
 
 def test_compute_inverse_distance_matrix():
@@ -16,3 +20,24 @@ def test_compute_inverse_distance_matrix():
     )
 
     assert numpy.allclose(expected, inverse_distances)
+
+
+def test_reorder_conformer():
+    """Tests that conformers can be correctly re-ordered."""
+
+    # Check the simple case where no re-ordering should occur.
+    oe_molecule = smiles_to_molecule("[C:1]([H:2])([H:3])([H:4])[H:5]")
+    conformer = numpy.array([[index, 0.0, 0.0] for index in range(5)])
+
+    reordered_conformer = reorder_conformer(oe_molecule, conformer)
+    assert numpy.allclose(reordered_conformer, conformer)
+
+    # Check a case where things are actually re-ordered simple case where no
+    # re-ordering should occur.
+    oe_molecule = smiles_to_molecule("[C:5]([H:1])([H:4])([H:2])[H:3]")
+
+    conformer = numpy.array([[index, 0.0, 0.0] for index in range(5)])
+    expected_conformer = conformer[numpy.array([4, 0, 3, 1, 2])]
+
+    reordered_conformer = reorder_conformer(oe_molecule, conformer)
+    assert numpy.allclose(reordered_conformer, expected_conformer)

--- a/openff/recharge/utilities/geometry.py
+++ b/openff/recharge/utilities/geometry.py
@@ -1,4 +1,5 @@
 import numpy
+from openeye import oechem
 
 
 def compute_inverse_distance_matrix(points_a: numpy.ndarray, points_b: numpy.ndarray):

--- a/openff/recharge/utilities/geometry.py
+++ b/openff/recharge/utilities/geometry.py
@@ -34,3 +34,21 @@ def compute_inverse_distance_matrix(points_a: numpy.ndarray, points_b: numpy.nda
             inverse_distances[i, j] = 1.0 / distance
 
     return inverse_distances
+
+
+def reorder_conformer(
+    oe_molecule: oechem.OEMol, conformer: numpy.ndarray
+) -> numpy.ndarray:
+    """Reorder a conformer to match the ordering of the atoms
+    in a molecule. The map index on each atom in the molecule
+    should match the original orderings of the atoms for which
+    the conformer was generated."""
+
+    index_map = {atom.GetIdx(): atom.GetMapIdx() for atom in oe_molecule.GetAtoms()}
+
+    indices = numpy.array(
+        [index_map[index] - 1 for index in range(oe_molecule.NumAtoms())]
+    )
+
+    reordered_conformer = conformer[indices]
+    return reordered_conformer


### PR DESCRIPTION
## Description
This PR adds a utility to re-order a molecules conformer to match the new atom ordering, whereby the old ordering is stored in a tagged smiles pattern.

## Status
- [X] Ready to go