### PR TITLE
Rename BCC Classes to be More Obvious and Consistent

### DIFF
--- a/openff/recharge/optimize/optimize.py
+++ b/openff/recharge/optimize/optimize.py
@@ -3,7 +3,7 @@ from typing import List
 import numpy
 from openeye import oechem
 
-from openff.recharge.charges.bcc import BCCGenerator, BCCSettings
+from openff.recharge.charges.bcc import BCCCollection, BCCGenerator
 from openff.recharge.charges.charges import ChargeGenerator, ChargeSettings
 from openff.recharge.esp.storage import MoleculeESPRecord, MoleculeESPStore
 from openff.recharge.utilities.geometry import (
@@ -122,7 +122,7 @@ class ESPOptimization:
         cls,
         smiles: List[str],
         esp_store: MoleculeESPStore,
-        bcc_settings: BCCSettings,
+        bcc_collection: BCCCollection,
         fixed_parameter_indices: List[int],
         charge_settings: ChargeSettings,
     ) -> List[PrecalulatedTerms]:
@@ -138,11 +138,10 @@ class ESPOptimization:
             The SMILES patterns of the molecules being optimised against.
         esp_store
             The store which contains the calculated ESP records.
-        bcc_settings
-            The settings which describe the parameters which are to be trained,
-            and how they should be applied to molecules.
+        bcc_collection
+            The collection of bond charge correction parameter to be trained.
         fixed_parameter_indices
-            The indices of the bond charge parameters specified by ``bcc_settings``
+            The indices of the bond charge parameters specified by ``bcc_collection``
             which should be kept fixed while training.
         charge_settings
             The settings which define how to calculate the uncorrected partial charges
@@ -154,7 +153,7 @@ class ESPOptimization:
         trainable_parameter_indices = numpy.array(
             [
                 i
-                for i in range(len(bcc_settings.bond_charge_corrections))
+                for i in range(len(bcc_collection.parameters))
                 if i not in fixed_parameter_indices
             ]
         )
@@ -175,7 +174,7 @@ class ESPOptimization:
                     atom.SetMapIdx(0)
 
                 assignment_matrix = BCCGenerator.build_assignment_matrix(
-                    oe_molecule, bcc_settings
+                    oe_molecule, bcc_collection
                 )
                 assignment_matrix = assignment_matrix[:, trainable_parameter_indices]
 

--- a/openff/recharge/tests/optimize/test_optimize.py
+++ b/openff/recharge/tests/optimize/test_optimize.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 import numpy
 
-from openff.recharge.charges.bcc import BCCSettings, BondChargeCorrection
+from openff.recharge.charges.bcc import BCCCollection, BCCParameter
 from openff.recharge.charges.charges import ChargeSettings
 from openff.recharge.esp import ESPSettings
 from openff.recharge.esp.storage import MoleculeESPRecord, MoleculeESPStore
@@ -73,17 +73,17 @@ def test_compute_objective_function():
 
 def test_precalculate(tmp_path):
 
-    bcc_settings = BCCSettings(
-        bond_charge_corrections=[
-            BondChargeCorrection(smirks="[#6:1]-[#1:2]", value=1.0, provenance={}),
-            BondChargeCorrection(smirks="[#6:1]#[#6:2]", value=2.0, provenance={}),
+    bcc_collection = BCCCollection(
+        parameters=[
+            BCCParameter(smirks="[#6:1]-[#1:2]", value=1.0, provenance={}),
+            BCCParameter(smirks="[#6:1]#[#6:2]", value=2.0, provenance={}),
         ]
     )
 
     precalculated_terms = ESPOptimization.precalculate(
         ["C#C"],
         MockMoleculeESPStore(f"{tmp_path}.sqlite"),
-        bcc_settings,
+        bcc_collection,
         [1],
         ChargeSettings(),
     )

--- a/scripts/convert-am1-bcc/convert.py
+++ b/scripts/convert-am1-bcc/convert.py
@@ -14,7 +14,7 @@ from typing import Dict, List
 import pandas
 from openeye import oechem
 
-from openff.recharge.charges.bcc import BondChargeCorrection
+from openff.recharge.charges.bcc import BCCParameter
 from openff.recharge.utilities.exceptions import InvalidSmirksError
 from openff.recharge.utilities.openeye import call_openeye
 
@@ -27,7 +27,7 @@ def build_bond_charge_corrections(
     bond_codes: Dict[str, str],
     bcc_overrides: Dict[str, float],
     custom_bcc_smirks: Dict[str, str],
-) -> List[BondChargeCorrection]:
+) -> List[BCCParameter]:
 
     # Convert the atom and bond codes into the six number codes used
     # in the AM1BCC paper.
@@ -88,7 +88,7 @@ def build_bond_charge_corrections(
 
         value = bcc_overrides.get(code, bcc_row["BCC"])
 
-        bond_charge_corrections[code] = BondChargeCorrection(
+        bond_charge_corrections[code] = BCCParameter(
             smirks=smirks, value=value, provenance={"code": code}
         )
 

--- a/scripts/pytorch/optimize.py
+++ b/scripts/pytorch/optimize.py
@@ -2,8 +2,8 @@ import torch
 import torch.optim
 
 from openff.recharge.charges.bcc import (
+    BCCCollection,
     BCCGenerator,
-    BCCSettings,
     original_am1bcc_corrections,
 )
 from openff.recharge.charges.charges import ChargeSettings
@@ -23,7 +23,7 @@ def main():
     # and fix any with a fixed zero value
     bcc_parameters = BCCGenerator.applied_corrections(
         *[smiles_to_molecule(smiles_pattern) for smiles_pattern in smiles],
-        settings=BCCSettings(bond_charge_corrections=original_am1bcc_corrections()),
+        bcc_collection=original_am1bcc_corrections(),
     )
     fixed_parameter_indices = [
         index
@@ -32,7 +32,7 @@ def main():
         == bcc_parameters[index].provenance["code"][-2:]
     ]
 
-    bcc_settings = BCCSettings(bond_charge_corrections=bcc_parameters)
+    bcc_collection = BCCCollection(parameters=bcc_parameters)
     charge_settings = ChargeSettings()
 
     # Define the starting parameters
@@ -50,7 +50,7 @@ def main():
     # evaluate the objective function, but do not depend on the
     # current parameters.
     precalculated_terms = ESPOptimization.precalculate(
-        smiles, esp_store, bcc_settings, fixed_parameter_indices, charge_settings
+        smiles, esp_store, bcc_collection, fixed_parameter_indices, charge_settings
     )
 
     for precalculated_term in precalculated_terms:

--- a/scripts/validation/validate.py
+++ b/scripts/validation/validate.py
@@ -11,7 +11,7 @@ from openeye import oechem
 from tqdm import tqdm
 
 from openff.recharge.charges.bcc import (
-    BondChargeCorrection,
+    BCCParameter,
     compare_openeye_parity,
     original_am1bcc_corrections,
 )
@@ -194,7 +194,7 @@ def coverage_molecules() -> List[str]:
 
 
 def match_bcc_parameters(
-    smiles: str, bond_charge_corrections: List[BondChargeCorrection]
+    smiles: str, bond_charge_corrections: List[BCCParameter]
 ) -> List[str]:
     """Returns the list of bond charge correction SMIRKS patterns which a molecule
     defined by it's SMILES pattern will exercise.
@@ -240,7 +240,7 @@ def map_smiles_to_smirks(smiles: List[str]) -> Dict[str, List[str]]:
     print("Mapping smiles to smirks.")
 
     match_function = functools.partial(
-        match_bcc_parameters, bond_charge_corrections=original_am1bcc_corrections()
+        match_bcc_parameters, parameters=original_am1bcc_corrections().parameters
     )
 
     with Pool(processes=4) as pool:
@@ -276,11 +276,13 @@ def main():
             smiles_per_smirks = json.load(file)
 
     # Check which bond charge correction parameters weren't covered by the set.
-    all_bcc_codes = {bcc.provenance["code"] for bcc in original_am1bcc_corrections()}
+    all_bcc_codes = {
+        bcc.provenance["code"] for bcc in original_am1bcc_corrections().parameters
+    }
 
     covered_codes = {
         bcc.provenance["code"]
-        for bcc in original_am1bcc_corrections()
+        for bcc in original_am1bcc_corrections().parameters
         if bcc.smirks in smiles_per_smirks
     }
 


### PR DESCRIPTION
## Description
This PR renames `BondChargeCorrection` to `BCCParameter` and `BCCSettings` to `BCCCollection` to be more consistent with the naming styles of the rest of the repository, and to be more obvious as to what data they represent.

## Status
- [X] Ready to go