### PR TITLE
Standardise Conformer Generation to use Factory + Settings Pattern

### DIFF
--- a/openff/recharge/charges/bcc.py
+++ b/openff/recharge/charges/bcc.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field, constr
 
 from openff.recharge.charges.charges import ChargeGenerator, ChargeSettings
 from openff.recharge.charges.exceptions import UnableToAssignChargeError
-from openff.recharge.conformers.conformers import OmegaELF10
+from openff.recharge.conformers import ConformerGenerator, ConformerSettings
 from openff.recharge.utilities import get_data_file_path
 from openff.recharge.utilities.openeye import match_smirks
 
@@ -591,7 +591,10 @@ def compare_openeye_parity(oe_molecule: oechem.OEMol) -> bool:
     bond_charge_corrections = original_am1bcc_corrections()
 
     # Generate a conformer for the molecule.
-    conformers = OmegaELF10.generate(oe_molecule, max_conformers=1)
+    conformers = ConformerGenerator.generate(
+        oe_molecule,
+        ConformerSettings(method="omega", sampling_mode="sparse", max_conformers=1),
+    )
 
     # Generate a set of reference charges using the OpenEye implementation
     reference_charges = ChargeGenerator.generate(

--- a/openff/recharge/conformers/__init__.py
+++ b/openff/recharge/conformers/__init__.py
@@ -1,0 +1,3 @@
+from openff.recharge.conformers.conformers import ConformerGenerator, ConformerSettings
+
+__all__ = [ConformerGenerator, ConformerSettings]

--- a/openff/recharge/conformers/conformers.py
+++ b/openff/recharge/conformers/conformers.py
@@ -1,6 +1,4 @@
-"""A module for generating conformers with a focus on generating extended conformers
-(i.e. conformers where strongly polar groups are not interacting)."""
-import abc
+"""A module for generating conformers for molecules."""
 import logging
 from typing import List, Optional
 
@@ -33,7 +31,7 @@ class ConformerSettings(BaseModel):
     )
 
 
-class ConformerGenerator(abc.ABC):
+class ConformerGenerator:
     """A class to generate a set of conformers for a molecule according to
     a specified set of settings.
     """

--- a/openff/recharge/conformers/conformers.py
+++ b/openff/recharge/conformers/conformers.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 
 import numpy
 from openeye import oechem, oeomega, oequacpac
+from pydantic import BaseModel, Field
+from typing_extensions import Literal
 
 from openff.recharge.charges.exceptions import OEQuacpacError
 from openff.recharge.conformers.exceptions import OEOmegaError
@@ -14,52 +16,56 @@ from openff.recharge.utilities.openeye import call_openeye, molecule_to_conforme
 logger = logging.getLogger()
 
 
+class ConformerSettings(BaseModel):
+    """The settings to use when generating conformers for a
+    particular molecule.
+    """
+
+    method: Literal["omega", "omega-elf10"] = Field(
+        "omega-elf10", description="The method to use to generate the conformers."
+    )
+    sampling_mode: Literal["sparse", "dense"] = Field(
+        "dense", description="The mode in which to generate the conformers."
+    )
+
+    max_conformers: Optional[int] = Field(
+        5, description="The maximum number of conformers to generate."
+    )
+
+
 class ConformerGenerator(abc.ABC):
-    """A base class for classes which will generate charges for a
-    given molecule"""
+    """A class to generate a set of conformers for a molecule according to
+    a specified set of settings.
+    """
 
     @classmethod
-    @abc.abstractmethod
-    def generate(cls, oe_molecule: oechem.OEMol) -> oechem.OEMol:
-        """Generates a set of conformers for a given molecule..
+    def generate(
+        cls, oe_molecule: oechem.OEMol, settings: ConformerSettings,
+    ) -> List[numpy.ndarray]:
+        """Generates a set of conformers for a given molecule.
 
         Notes
         -----
         * All operations are performed on a copy of the original molecule so that it
-        will not be mutated by this function. The generated conformers will be
-        available on the return molecule instead.
-
-        * Any existing conformers on the given molecule will be discarded.
+        will not be mutated by this function.
 
         Parameters
         ----------
         oe_molecule
             The molecule to generate conformers for.
-        """
-
-
-class OmegaELF10(ConformerGenerator):
-    """A conformer generator which initial generates a diverse set of conformers
-     using the OpenEye Omega toolkit, and then prunes those conformers based
-     upon the OpenEYE ELF10 implementation."""
-
-    @classmethod
-    def generate(
-        cls, oe_molecule: oechem.OEMol, max_conformers: Optional[int] = 5,
-    ) -> List[numpy.ndarray]:
-        """
-        Parameters
-        ----------
-        oe_molecule
-            The molecule to generate conformers for.
-        max_conformers
-            The maximum number of conformers to be generated.
+        settings
+            The settings to generate the conformers according to.
         """
 
         oe_molecule = oechem.OEMol(oe_molecule)
 
         # Enable dense sampling of conformers
-        omega_options = oeomega.OEOmegaOptions(oeomega.OEOmegaSampling_Dense)
+        if settings.sampling_mode == "sparse":
+            omega_options = oeomega.OEOmegaOptions(oeomega.OEOmegaSampling_Sparse)
+        elif settings.sampling_mode == "dense":
+            omega_options = oeomega.OEOmegaOptions(oeomega.OEOmegaSampling_Dense)
+        else:
+            raise NotImplementedError()
 
         omega = oeomega.OEOmega(omega_options)
         omega.SetIncludeInput(False)
@@ -67,21 +73,23 @@ class OmegaELF10(ConformerGenerator):
 
         call_openeye(omega, oe_molecule, exception_type=OEOmegaError)
 
-        # Select a subset of the OMEGA generated conformers using the ELF10 method.
-        charge_engine = oequacpac.OEELFCharges(
-            oequacpac.OEAM1BCCCharges(), 10, 2.0, True
-        )
+        if settings.method == "omega-elf10":
 
-        call_openeye(
-            oequacpac.OEAssignCharges,
-            oe_molecule,
-            charge_engine,
-            exception_type=OEQuacpacError,
-        )
+            # Select a subset of the OMEGA generated conformers using the ELF10 method.
+            charge_engine = oequacpac.OEELFCharges(
+                oequacpac.OEAM1BCCCharges(), 10, 2.0, True
+            )
+
+            call_openeye(
+                oequacpac.OEAssignCharges,
+                oe_molecule,
+                charge_engine,
+                exception_type=OEQuacpacError,
+            )
 
         conformers = molecule_to_conformers(oe_molecule)
 
-        if max_conformers:
-            conformers = conformers[0 : min(max_conformers, len(conformers))]
+        if settings.max_conformers:
+            conformers = conformers[0 : min(settings.max_conformers, len(conformers))]
 
         return conformers

--- a/openff/recharge/tests/conformers/test_conformers.py
+++ b/openff/recharge/tests/conformers/test_conformers.py
@@ -1,11 +1,40 @@
-from openff.recharge.conformers.conformers import OmegaELF10
+from typing import Optional
+
+import pytest
+
+from openff.recharge.conformers import ConformerGenerator, ConformerSettings
 from openff.recharge.utilities.openeye import smiles_to_molecule
 
 
-def test_omega_elf10():
-    """Tests the `OmegaELF10` generator can generate conformers without
-    issue.
+def test_max_conformers():
+    """Tests the conformer generator returns back a number of conformers less than
+    or equal to the maximum.
     """
+    oe_molecule = smiles_to_molecule("CCOCO")
 
+    assert (
+        len(
+            ConformerGenerator.generate(
+                oe_molecule, ConformerSettings(max_conformers=1)
+            )
+        )
+        == 1
+    )
+
+
+@pytest.mark.parametrize("method", ["omega", "omega-elf10"])
+@pytest.mark.parametrize("sampling_mode", ["dense", "sparse"])
+@pytest.mark.parametrize("max_conformers", [1, None])
+def test_generate_conformers(
+    method: str, sampling_mode: str, max_conformers: Optional[int]
+):
+    """Tests conformer generator."""
     oe_molecule = smiles_to_molecule("CO")
-    assert len(OmegaELF10.generate(oe_molecule, max_conformers=1)) == 1
+
+    # noinspection PyTypeChecker
+    ConformerGenerator.generate(
+        oe_molecule,
+        ConformerSettings(
+            method=method, sampling_mode=sampling_mode, max_conformers=max_conformers
+        ),
+    )

--- a/scripts/pytorch/generate_esp.py
+++ b/scripts/pytorch/generate_esp.py
@@ -2,7 +2,7 @@ import functools
 from multiprocessing import Pool
 from typing import List
 
-from openff.recharge.conformers.conformers import OmegaELF10
+from openff.recharge.conformers import ConformerGenerator, ConformerSettings
 from openff.recharge.esp import ESPSettings
 from openff.recharge.esp.psi4 import Psi4ESPGenerator
 from openff.recharge.esp.storage import MoleculeESPRecord, MoleculeESPStore
@@ -13,7 +13,7 @@ N_PROCESSES = 4
 
 
 def compute_esp(
-    smiles: str, n_conformers: int, settings: ESPSettings
+    smiles: str, max_conformers: int, settings: ESPSettings
 ) -> List[MoleculeESPRecord]:
     """Compute the ESP for a molecule in different conformers.
 
@@ -21,7 +21,7 @@ def compute_esp(
     ----------
     smiles
         The SMILES representation of the molecule.
-    n_conformers
+    max_conformers
         The target number of conformers to compute the ESP of.
     settings
         The settings to use when generating the ESP.
@@ -30,7 +30,9 @@ def compute_esp(
     oe_molecule = smiles_to_molecule(smiles)
 
     # Generate a set of conformers for the molecule.
-    conformers = OmegaELF10.generate(oe_molecule, n_conformers)
+    conformers = ConformerGenerator.generate(
+        oe_molecule, ConformerSettings(max_conformers=max_conformers)
+    )
 
     esp_records = []
 
@@ -148,7 +150,7 @@ def main():
                 esp_record
                 for esp_records in pool.map(
                     functools.partial(
-                        compute_esp, n_conformers=5, settings=esp_settings
+                        compute_esp, max_conformers=5, settings=esp_settings
                     ),
                     smiles,
                 )


### PR DESCRIPTION
## Description
This PR standardises the conformer generator such that there is now a single conformer generation factory which accepts a settings object.

## Status
- [x] Ready to go