### PR TITLE
Replace Decimal Type in ESP Store with Float Stored as Int

### DIFF
--- a/openff/recharge/esp/storage/db.py
+++ b/openff/recharge/esp/storage/db.py
@@ -1,10 +1,8 @@
 import abc
 import math
-from decimal import Decimal
 from typing import TypeVar
 
 from sqlalchemy import (
-    DECIMAL,
     Boolean,
     Column,
     Float,
@@ -24,7 +22,16 @@ DBBase = declarative_base()
 _InstanceType = TypeVar("_InstanceType")
 _DBInstanceType = TypeVar("_DBInstanceType")
 
-FLOAT_PRECISION = 100000.0
+DB_VERSION = 1
+_DB_FLOAT_PRECISION = 100000.0
+
+
+def _float_to_db_int(value: float) -> int:
+    return int(math.floor(value * _DB_FLOAT_PRECISION))
+
+
+def _db_int_to_float(value: int) -> float:
+    return value / _DB_FLOAT_PRECISION
 
 
 class _UniqueMixin:
@@ -112,28 +119,28 @@ class DBGridSettings(_UniqueMixin, DBBase):
     id = Column(Integer, primary_key=True, index=True)
 
     type = Column(String, nullable=False)
-    spacing = Column(DECIMAL, nullable=False)
+    spacing = Column(Integer, nullable=False)
 
-    inner_vdw_scale = Column(DECIMAL, nullable=False)
-    outer_vdw_scale = Column(DECIMAL, nullable=False)
+    inner_vdw_scale = Column(Integer, nullable=False)
+    outer_vdw_scale = Column(Integer, nullable=False)
 
     @classmethod
     def _hash(cls, instance: GridSettings) -> int:
         return hash(
             (
                 instance.type,
-                f"{instance.spacing:.5f}",
-                f"{instance.inner_vdw_scale:.5f}",
-                f"{instance.outer_vdw_scale:.5f}",
+                _float_to_db_int(instance.spacing),
+                _float_to_db_int(instance.inner_vdw_scale),
+                _float_to_db_int(instance.outer_vdw_scale),
             )
         )
 
     @classmethod
     def _query(cls, db: Session, instance: GridSettings) -> Query:
 
-        spacing = Decimal(round(instance.spacing, 5))
-        inner_vdw_scale = Decimal(round(instance.inner_vdw_scale, 5))
-        outer_vdw_scale = Decimal(round(instance.outer_vdw_scale, 5))
+        spacing = _float_to_db_int(instance.spacing)
+        inner_vdw_scale = _float_to_db_int(instance.inner_vdw_scale)
+        outer_vdw_scale = _float_to_db_int(instance.outer_vdw_scale)
 
         return (
             db.query(DBGridSettings)
@@ -145,16 +152,22 @@ class DBGridSettings(_UniqueMixin, DBBase):
 
     @classmethod
     def _instance_to_db(cls, instance: GridSettings) -> "DBGridSettings":
-
-        spacing = Decimal(round(instance.spacing, 5))
-        inner_vdw_scale = Decimal(round(instance.inner_vdw_scale, 5))
-        outer_vdw_scale = Decimal(round(instance.outer_vdw_scale, 5))
-
         return DBGridSettings(
             type=instance.type,
-            spacing=spacing,
-            inner_vdw_scale=inner_vdw_scale,
-            outer_vdw_scale=outer_vdw_scale,
+            spacing=_float_to_db_int(instance.spacing),
+            inner_vdw_scale=_float_to_db_int(instance.inner_vdw_scale),
+            outer_vdw_scale=_float_to_db_int(instance.outer_vdw_scale),
+        )
+
+    @classmethod
+    def db_to_instance(cls, db_instance: "DBGridSettings") -> GridSettings:
+
+        # noinspection PyTypeChecker
+        return GridSettings(
+            type=db_instance.type,
+            spacing=_db_int_to_float(db_instance.spacing),
+            inner_vdw_scale=_db_int_to_float(db_instance.inner_vdw_scale),
+            outer_vdw_scale=_db_int_to_float(db_instance.outer_vdw_scale),
         )
 
 
@@ -180,14 +193,14 @@ class DBPCMSettings(_UniqueMixin, DBBase):
                 instance.solvent,
                 instance.radii_model,
                 instance.radii_scaling,
-                int(math.floor(instance.cavity_area * FLOAT_PRECISION)),
+                _float_to_db_int(instance.cavity_area),
             )
         )
 
     @classmethod
     def _query(cls, db: Session, instance: PCMSettings) -> Query:
 
-        cavity_area = int(math.floor(instance.cavity_area * FLOAT_PRECISION))
+        cavity_area = _float_to_db_int(instance.cavity_area)
 
         return (
             db.query(DBPCMSettings)
@@ -201,20 +214,16 @@ class DBPCMSettings(_UniqueMixin, DBBase):
     @classmethod
     def _instance_to_db(cls, instance: PCMSettings) -> "DBPCMSettings":
 
-        cavity_area = int(math.floor(instance.cavity_area * FLOAT_PRECISION))
-
         return DBPCMSettings(
             solver=instance.solver,
             solvent=instance.solvent,
             radii_model=instance.radii_model,
             radii_scaling=instance.radii_scaling,
-            cavity_area=cavity_area,
+            cavity_area=_float_to_db_int(instance.cavity_area),
         )
 
     @classmethod
     def db_to_instance(cls, db_instance: "DBPCMSettings") -> PCMSettings:
-
-        cavity_area = db_instance.cavity_area / FLOAT_PRECISION
 
         # noinspection PyTypeChecker
         return PCMSettings(
@@ -222,7 +231,7 @@ class DBPCMSettings(_UniqueMixin, DBBase):
             solvent=db_instance.solvent,
             radii_model=db_instance.radii_model,
             radii_scaling=db_instance.radii_scaling,
-            cavity_area=cavity_area,
+            cavity_area=_db_int_to_float(db_instance.cavity_area),
         )
 
 
@@ -281,3 +290,13 @@ class DBMoleculeRecord(DBBase):
 
     smiles = Column(String, primary_key=True, index=True)
     conformers = relationship("DBConformerRecord")
+
+
+class DBInformation(DBBase):
+    """A class which keeps track of the current database
+    settings.
+    """
+
+    __tablename__ = "db_info"
+
+    version = Column(Integer, primary_key=True)

--- a/openff/recharge/esp/storage/exceptions.py
+++ b/openff/recharge/esp/storage/exceptions.py
@@ -1,0 +1,29 @@
+from openff.recharge.utilities.exceptions import RechargeException
+
+
+class IncompatibleDBVersion(RechargeException):
+    """An exception raised when attempting to load an ESP store whose
+    version does not match the version expected by the framework.
+    """
+
+    def __init__(self, found_version: int, expected_version: int):
+        """
+
+        Parameters
+        ----------
+        found_version
+            The version of the database being loaded.
+        expected_version
+            The expected version of the database.
+        """
+
+        super(IncompatibleDBVersion, self).__init__(
+            f"The database being loaded is currently at version {found_version} "
+            f"while the framework expects a version of {expected_version}. There "
+            f"is no way to upgrade the database at this time, although this may "
+            f"be added in future versions. Either regenerate the database, or use "
+            f"an older compatible version of the `openff-recharge` framework."
+        )
+
+        self.found_version = found_version
+        self.expected_version = expected_version


### PR DESCRIPTION
## Description
This PR replaces the decimal column type (which is not supported by SQLite) currently used in the ESP store with an integer representation of a float with the precision tied to a new DB version. This version gets automatically added to new ESP stores and is validated against the frameworks supported version.

## Status
- [X] Ready to go