### PR TITLE
Return Applied Corrections In Original Order

### DIFF
--- a/openff/recharge/charges/bcc.py
+++ b/openff/recharge/charges/bcc.py
@@ -519,6 +519,7 @@ class BCCGenerator:
                 if bcc_collection.parameters[index] not in applied_corrections
             )
 
+        applied_corrections.sort(key=lambda x: bcc_collection.parameters.index(x))
         return applied_corrections
 
     @classmethod

--- a/openff/recharge/tests/charges/test_bcc.py
+++ b/openff/recharge/tests/charges/test_bcc.py
@@ -58,6 +58,27 @@ def test_applied_corrections():
     assert applied_corrections[0] == bcc_collection.parameters[1]
 
 
+def test_applied_corrections_order():
+    """Ensure that the applied corrections are returned in the correct order
+    when applying them to multiple molecules."""
+
+    bcc_collection = BCCCollection(
+        parameters=[
+            BCCParameter(smirks="[#7:1]-[#1:2]", value=1.0, provenance={}),
+            BCCParameter(smirks="[#6:1]-[#1:2]", value=1.0, provenance={}),
+        ]
+    )
+
+    applied_corrections = BCCGenerator.applied_corrections(
+        smiles_to_molecule("C"), smiles_to_molecule("N"), bcc_collection=bcc_collection
+    )
+
+    assert len(applied_corrections) == 2
+
+    assert applied_corrections[0] == bcc_collection.parameters[0]
+    assert applied_corrections[1] == bcc_collection.parameters[1]
+
+
 def test_apply_assignment():
 
     settings = BCCCollection(


### PR DESCRIPTION
## Description
This PR fixes a bug whereby the order of applied corrections returned by `BCCGenerator.applied_corrections` depended on the order of the passed molecules. This is problematic when attempting to create a `BCCCollection` containing only the subset of applied parameters as they would then be applied in a different order than the original set.

## Status
- [X] Ready to go