### PR TITLE
Fix Psi4 SEGFAULT on OSX CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
         shell: bash -l {0}
         run: |
 
-          conda install --yes -c conda-forge -c psi4/label/dev psi4
+          conda install --yes -c conda-forge -c psi4/label/dev "psi4 <=1.4a2.dev215"
 
       - name: Install Package
         shell: bash -l {0}


### PR DESCRIPTION
## Description
This PR attempts to fix the SEGFAULT occurring on OSX CI jobs by pinning to an older version of `psi4`.

## Status
- [x] Ready to go