### PR TITLE
Make Package Importable Without OE Installed

### DIFF
--- a/openff/recharge/charges/charges.py
+++ b/openff/recharge/charges/charges.py
@@ -1,15 +1,21 @@
 """This module contains classes which will generate partial charges using a combination
 of a cheaper QM method and a set of bond charge corrections.
 """
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import numpy
-from openeye import oechem, oequacpac
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 from openff.recharge.charges.exceptions import OEQuacpacError
-from openff.recharge.utilities.openeye import call_openeye
+from openff.recharge.utilities.openeye import (
+    call_openeye,
+    import_oechem,
+    import_oequacpac,
+)
+
+if TYPE_CHECKING:
+    from openeye import oechem
 
 
 class ChargeSettings(BaseModel):
@@ -40,7 +46,7 @@ class ChargeGenerator:
     @classmethod
     def generate(
         cls,
-        oe_molecule: oechem.OEMol,
+        oe_molecule: "oechem.OEMol",
         conformers: List[numpy.ndarray],
         settings: ChargeSettings,
     ) -> numpy.ndarray:
@@ -61,6 +67,9 @@ class ChargeGenerator:
         -------
             The computed partial charges.
         """
+
+        oechem = import_oechem()
+        oequacpac = import_oequacpac()
 
         # Make a copy of the molecule so as not to perturb the original.
         oe_molecule = oechem.OEMol(oe_molecule)

--- a/openff/recharge/conformers/conformers.py
+++ b/openff/recharge/conformers/conformers.py
@@ -1,15 +1,23 @@
 """A module for generating conformers for molecules."""
 import logging
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import numpy
-from openeye import oechem, oeomega, oequacpac
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 from openff.recharge.charges.exceptions import OEQuacpacError
 from openff.recharge.conformers.exceptions import OEOmegaError
-from openff.recharge.utilities.openeye import call_openeye, molecule_to_conformers
+from openff.recharge.utilities.openeye import (
+    call_openeye,
+    import_oechem,
+    import_oeomega,
+    import_oequacpac,
+    molecule_to_conformers,
+)
+
+if TYPE_CHECKING:
+    from openeye import oechem
 
 logger = logging.getLogger()
 
@@ -39,7 +47,7 @@ class ConformerGenerator:
     @classmethod
     def generate(
         cls,
-        oe_molecule: oechem.OEMol,
+        oe_molecule: "oechem.OEMol",
         settings: ConformerSettings,
     ) -> List[numpy.ndarray]:
         """Generates a set of conformers for a given molecule.
@@ -56,6 +64,10 @@ class ConformerGenerator:
         settings
             The settings to generate the conformers according to.
         """
+
+        oechem = import_oechem()
+        oeomega = import_oeomega()
+        oequacpac = import_oequacpac()
 
         oe_molecule = oechem.OEMol(oe_molecule)
 

--- a/openff/recharge/esp/esp.py
+++ b/openff/recharge/esp/esp.py
@@ -3,13 +3,14 @@ import os
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy
-from openeye.oechem import OEMol
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 from openff.recharge.grids import GridGenerator, GridSettings
 
 if TYPE_CHECKING:
+    from openeye import oechem
+
     PositiveFloat = float
 else:
     from pydantic import PositiveFloat
@@ -72,7 +73,7 @@ class ESPGenerator(abc.ABC):
     @abc.abstractmethod
     def _generate(
         cls,
-        oe_molecule: OEMol,
+        oe_molecule: "oechem.OEMol",
         conformer: numpy.ndarray,
         grid: numpy.ndarray,
         settings: ESPSettings,
@@ -105,7 +106,7 @@ class ESPGenerator(abc.ABC):
     @classmethod
     def generate(
         cls,
-        oe_molecule: OEMol,
+        oe_molecule: "oechem.OEMol",
         conformer: numpy.ndarray,
         settings: ESPSettings,
         directory: str = None,

--- a/openff/recharge/esp/psi4.py
+++ b/openff/recharge/esp/psi4.py
@@ -1,14 +1,17 @@
 import os
 import subprocess
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple
 
 import jinja2
 import numpy
-from openeye import oechem
 
 from openff.recharge.esp import ESPGenerator, ESPSettings
 from openff.recharge.esp.exceptions import Psi4Error
 from openff.recharge.utilities import get_data_file_path, temporary_cd
+from openff.recharge.utilities.openeye import import_oechem
+
+if TYPE_CHECKING:
+    from openeye import oechem
 
 
 class Psi4ESPGenerator(ESPGenerator):
@@ -18,7 +21,10 @@ class Psi4ESPGenerator(ESPGenerator):
 
     @classmethod
     def _generate_input(
-        cls, oe_molecule: oechem.OEMol, conformer: numpy.ndarray, settings: ESPSettings
+        cls,
+        oe_molecule: "oechem.OEMol",
+        conformer: numpy.ndarray,
+        settings: ESPSettings,
     ) -> str:
         """Generate the input files for Psi4.
 
@@ -35,6 +41,8 @@ class Psi4ESPGenerator(ESPGenerator):
         -------
             The contents of the input file.
         """
+
+        oechem = import_oechem()
 
         # Compute the total formal charge on the molecule.
         formal_charge = sum(atom.GetFormalCharge() for atom in oe_molecule.GetAtoms())
@@ -95,7 +103,7 @@ class Psi4ESPGenerator(ESPGenerator):
     @classmethod
     def _generate(
         cls,
-        oe_molecule: oechem.OEMol,
+        oe_molecule: "oechem.OEMol",
         conformer: numpy.ndarray,
         grid: numpy.ndarray,
         settings: ESPSettings,

--- a/openff/recharge/grids/grids.py
+++ b/openff/recharge/grids/grids.py
@@ -2,11 +2,14 @@ import itertools
 from typing import TYPE_CHECKING
 
 import numpy
-from openeye import oechem
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
+from openff.recharge.utilities.openeye import import_oechem
+
 if TYPE_CHECKING:
+    from openeye import oechem
+
     PositiveFloat = float
 else:
     from pydantic import PositiveFloat
@@ -40,7 +43,10 @@ class GridGenerator:
 
     @classmethod
     def generate(
-        cls, oe_molecule: oechem.OEMol, conformer: numpy.ndarray, settings: GridSettings
+        cls,
+        oe_molecule: "oechem.OEMol",
+        conformer: numpy.ndarray,
+        settings: GridSettings,
     ) -> numpy.ndarray:
         """Generates a grid of points in a shell around a specified
         molecule in a given conformer according a set of settings.
@@ -59,6 +65,8 @@ class GridGenerator:
         -------
             The coordinates of the grid with shape=(n_grid_points, 3).
         """
+
+        oechem = import_oechem()
 
         # Only operate on a copy of the molecule.
         oe_molecule = oechem.OEMol(oe_molecule)

--- a/openff/recharge/optimize/optimize.py
+++ b/openff/recharge/optimize/optimize.py
@@ -2,7 +2,6 @@ import abc
 from typing import Generator, List
 
 import numpy
-from openeye import oechem
 
 from openff.recharge.charges.bcc import BCCCollection, BCCGenerator
 from openff.recharge.charges.charges import ChargeGenerator, ChargeSettings
@@ -14,6 +13,7 @@ from openff.recharge.utilities.geometry import (
     compute_vector_field,
     reorder_conformer,
 )
+from openff.recharge.utilities.openeye import import_oechem
 
 
 class ObjectiveTerm(abc.ABC):
@@ -181,6 +181,8 @@ class _Optimization(abc.ABC):
             The precalculated terms which may be used to compute the full
             contribution to the objective function.
         """
+
+        oechem = import_oechem()
 
         trainable_parameter_indices = numpy.array(
             [

--- a/openff/recharge/tests/utilities/test_openeye.py
+++ b/openff/recharge/tests/utilities/test_openeye.py
@@ -1,12 +1,18 @@
+import sys
+
 import numpy
 import pytest
 from openeye import oechem
 
 from openff.recharge.utilities.exceptions import (
     InvalidSmirksError,
+    MissingOptionalDependency,
     MoleculeFromSmilesError,
 )
 from openff.recharge.utilities.openeye import (
+    import_oechem,
+    import_oeomega,
+    import_oequacpac,
     match_smirks,
     molecule_to_conformers,
     smiles_to_molecule,
@@ -86,3 +92,75 @@ def test_molecule_to_conformer():
 
     assert conformers[0].shape == conformer.shape
     assert numpy.allclose(conformers[0], conformer)
+
+
+def test_missing_oechem(monkeypatch):
+    # Mock OE to be missing
+    monkeypatch.setitem(sys.modules, "openeye.oechem", None)
+
+    with pytest.raises(MissingOptionalDependency) as error_info:
+        import_oechem()
+
+    assert error_info.value.library_name == "openeye.oechem"
+    assert error_info.value.license_issue is False
+
+
+def test_missing_oeomega(monkeypatch):
+    # Mock OE to be missing
+    monkeypatch.setitem(sys.modules, "openeye.oeomega", None)
+
+    with pytest.raises(MissingOptionalDependency) as error_info:
+        import_oeomega()
+
+    assert error_info.value.library_name == "openeye.oeomega"
+    assert error_info.value.license_issue is False
+
+
+def test_missing_oequacpac(monkeypatch):
+    # Mock OE to be missing
+    monkeypatch.setitem(sys.modules, "openeye.oequacpac", None)
+
+    with pytest.raises(MissingOptionalDependency) as error_info:
+        import_oequacpac()
+
+    assert error_info.value.library_name == "openeye.oequacpac"
+    assert error_info.value.license_issue is False
+
+
+def test_missing_oechem_license(monkeypatch):
+
+    from openeye import oechem
+
+    monkeypatch.setattr(oechem, "OEChemIsLicensed", lambda: False)
+
+    with pytest.raises(MissingOptionalDependency) as error_info:
+        import_oechem()
+
+    assert error_info.value.library_name == "openeye.oechem"
+    assert error_info.value.license_issue is True
+
+
+def test_missing_oeomega_license(monkeypatch):
+
+    from openeye import oeomega
+
+    monkeypatch.setattr(oeomega, "OEOmegaIsLicensed", lambda: False)
+
+    with pytest.raises(MissingOptionalDependency) as error_info:
+        import_oeomega()
+
+    assert error_info.value.library_name == "openeye.oeomega"
+    assert error_info.value.license_issue is True
+
+
+def test_missing_oequacpac_license(monkeypatch):
+
+    from openeye import oequacpac
+
+    monkeypatch.setattr(oequacpac, "OEQuacPacIsLicensed", lambda: False)
+
+    with pytest.raises(MissingOptionalDependency) as error_info:
+        import_oequacpac()
+
+    assert error_info.value.library_name == "openeye.oequacpac"
+    assert error_info.value.license_issue is True

--- a/openff/recharge/utilities/exceptions.py
+++ b/openff/recharge/utilities/exceptions.py
@@ -1,4 +1,8 @@
 """A module containing general exceptions raised by the framework."""
+_CONDA_INSTALLATION_COMMANDS = {
+    "openforcefield": "conda install -c conda-forge -c omnia openforcefield",
+    "openeye": "conda install -c openeye openeye-toolkits",
+}
 
 
 class RechargeException(BaseException):
@@ -64,9 +68,16 @@ class MissingOptionalDependency(RechargeException):
         """
 
         message = f"The required {library_name} module could not be imported."
+        conda_command = _CONDA_INSTALLATION_COMMANDS.get(
+            library_name.split(".")[0], None
+        )
 
         if license_issue:
             message = f"{message} This is due to a missing license."
+        elif conda_command is not None:
+            message = (
+                f"{message} Try installing the package by running `{conda_command}`."
+            )
 
         super(MissingOptionalDependency, self).__init__(message)
 

--- a/openff/recharge/utilities/geometry.py
+++ b/openff/recharge/utilities/geometry.py
@@ -1,5 +1,9 @@
+from typing import TYPE_CHECKING
+
 import numpy
-from openeye import oechem
+
+if TYPE_CHECKING:
+    from openeye import oechem
 
 BOHR_TO_ANGSTROM = 0.529177210903  # NIST 2018 CODATA
 INVERSE_ANGSTROM_TO_BOHR = BOHR_TO_ANGSTROM
@@ -105,7 +109,7 @@ def compute_vector_field(
 
 
 def reorder_conformer(
-    oe_molecule: oechem.OEMol, conformer: numpy.ndarray
+    oe_molecule: "oechem.OEMol", conformer: numpy.ndarray
 ) -> numpy.ndarray:
     """Reorder a conformer to match the ordering of the atoms
     in a molecule. The map index on each atom in the molecule

--- a/openff/recharge/utilities/openeye.py
+++ b/openff/recharge/utilities/openeye.py
@@ -1,27 +1,87 @@
 """A set of utilities to aid in interfacing with the OpenEye toolkits."""
+import importlib
 import logging
 import re
-from typing import Any, Callable, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Type, TypeVar
 
 import numpy
-from openeye import oechem, oeomega
+from typing_extensions import Literal
 
 from openff.recharge.utilities.exceptions import (
     InvalidSmirksError,
+    MissingOptionalDependency,
     MoleculeFromSmilesError,
     RechargeException,
 )
+
+if TYPE_CHECKING:
+    from openeye import oechem
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
 
+def _check_oe_library_available(
+    library_name: Literal["oechem", "oeomega", "oequacpac"]
+):
+    """Check if the specified ``openeye`` module is available for import
+    and is correctly licensed.
+
+    Raises
+    -------
+    MissingOptionalDependency
+    """
+    try:
+        library = importlib.import_module(f"openeye.{library_name}")
+    except (ImportError, ModuleNotFoundError):
+        raise MissingOptionalDependency(f"openeye.{library_name}", False)
+    except Exception as e:
+        raise e
+
+    unlicensed_library = False
+
+    if library_name == "oechem":
+        unlicensed_library = not library.OEChemIsLicensed()
+    elif library_name == "oeomega":
+        unlicensed_library = not library.OEOmegaIsLicensed()
+    elif library_name == "oequacpac":
+        unlicensed_library = not library.OEQuacPacIsLicensed()
+
+    if unlicensed_library:
+        raise MissingOptionalDependency(f"openeye.{library_name}", True)
+
+
+def import_oechem():
+
+    _check_oe_library_available("oechem")
+
+    from openeye import oechem
+
+    return oechem
+
+
+def import_oeomega():
+    _check_oe_library_available("oeomega")
+
+    from openeye import oeomega
+
+    return oeomega
+
+
+def import_oequacpac():
+    _check_oe_library_available("oequacpac")
+
+    from openeye import oequacpac
+
+    return oequacpac
+
+
 def call_openeye(
     oe_callable: Callable[[T], bool],
     *args: T,
     exception_type: Type[RechargeException] = RuntimeError,
-    exception_kwargs: Dict[str, Any] = None
+    exception_kwargs: Dict[str, Any] = None,
 ):
     """Wraps a call to an OpenEye function, either capturing the output in an
     exception if the function does not complete successfully, or redirecting it
@@ -39,6 +99,8 @@ def call_openeye(
     exception_kwargs
         The keyword arguments to pass to the exception.
     """
+
+    oechem = import_oechem()
 
     if exception_kwargs is None:
         exception_kwargs = {}
@@ -69,7 +131,7 @@ def call_openeye(
 
 def smiles_to_molecule(
     smiles: str, guess_stereochemistry: bool = False
-) -> oechem.OEMol:
+) -> "oechem.OEMol":
     """Attempts to parse a smiles pattern into a molecule object.
 
     Parameters
@@ -85,6 +147,9 @@ def smiles_to_molecule(
     -------
     The parsed molecule.
     """
+
+    oechem = import_oechem()
+    oeomega = import_oeomega()
 
     oe_molecule = oechem.OEMol()
 
@@ -122,7 +187,7 @@ def smiles_to_molecule(
 
 
 def match_smirks(
-    smirks: str, oe_molecule: oechem.OEMol, unique: bool = False
+    smirks: str, oe_molecule: "oechem.OEMol", unique: bool = False
 ) -> List[Dict[int, int]]:
     """Attempt to find the indices (optionally unique) of all atoms which
     match a particular SMIRKS pattern.
@@ -141,6 +206,8 @@ def match_smirks(
         A list of all the matches where each match is stored as a dictionary of
         the smirks indices and their corresponding matched atom indices.
     """
+
+    oechem = import_oechem()
 
     query = oechem.OEQMol()
     call_openeye(
@@ -169,7 +236,7 @@ def match_smirks(
     return matches
 
 
-def molecule_to_conformers(oe_molecule: oechem.OEMol) -> List[numpy.ndarray]:
+def molecule_to_conformers(oe_molecule: "oechem.OEMol") -> List[numpy.ndarray]:
     """Extracts the conformers of a molecule and stores them
     inside of a numpy array.
 


### PR DESCRIPTION
## Description
This PR moves all OE imports into function bodies and adds a nice exception when OE is missing explaining how it can be installed. 

Although OE is still required to use the main functionalities of the library, this allows the core data models to be used and accessed without having OE installed.

## Status
- [X] Ready to go