### PR TITLE
Add a CLI to Generate ESP from Schema Settings

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -14,6 +14,7 @@ dependencies:
 
     ### Core dependencies.
 
+  - click
   - numpy
   - pydantic
   - openeye-toolkits

--- a/openff/recharge/cli/__init__.py
+++ b/openff/recharge/cli/__init__.py
@@ -1,0 +1,3 @@
+from openff.recharge.cli.cli import cli
+
+__all__ = [cli]

--- a/openff/recharge/cli/cli.py
+++ b/openff/recharge/cli/cli.py
@@ -1,0 +1,11 @@
+import click
+
+from openff.recharge.cli.generate import generate
+
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(generate)

--- a/openff/recharge/cli/cli.py
+++ b/openff/recharge/cli/cli.py
@@ -5,7 +5,7 @@ from openff.recharge.cli.generate import generate
 
 @click.group()
 def cli():
-    pass
+    """The root CLI group for all ``openff-recharge`` commands"""
 
 
 cli.add_command(generate)

--- a/openff/recharge/cli/generate.py
+++ b/openff/recharge/cli/generate.py
@@ -1,0 +1,108 @@
+import functools
+import json
+from multiprocessing import Pool
+from typing import List
+
+import click
+
+from openff.recharge.conformers import ConformerGenerator, ConformerSettings
+from openff.recharge.esp import ESPSettings
+from openff.recharge.esp.psi4 import Psi4ESPGenerator
+from openff.recharge.esp.storage import MoleculeESPRecord, MoleculeESPStore
+from openff.recharge.utilities.openeye import smiles_to_molecule
+
+
+def _compute_esp(
+    smiles: str, conformer_settings: ConformerSettings, settings: ESPSettings
+) -> List[MoleculeESPRecord]:
+    """Compute the ESP for a molecule in different conformers.
+
+    Parameters
+    ----------
+    smiles
+        The SMILES representation of the molecule.
+    conformer_settings
+        The settings to use when generating the conformers.
+    settings
+        The settings to use when generating the ESP.
+    """
+
+    oe_molecule = smiles_to_molecule(smiles)
+
+    # Generate a set of conformers for the molecule.
+    conformers = ConformerGenerator.generate(oe_molecule, conformer_settings)
+
+    esp_records = []
+
+    for conformer in conformers:
+
+        grid_coordinates, esp, electric_field = Psi4ESPGenerator.generate(
+            oe_molecule, conformer, settings
+        )
+
+        esp_records.append(
+            MoleculeESPRecord.from_oe_molecule(
+                oe_molecule, conformer, grid_coordinates, esp, electric_field, settings
+            )
+        )
+
+    return esp_records
+
+
+@click.command(help="Generate electrostatic property data for a set of SMILES.")
+@click.option(
+    "--smiles",
+    default="smiles.json",
+    type=click.Path(exists=True, dir_okay=False),
+    help="The path to a JSON file containing the set of SMILES patterns.",
+    show_default=True,
+)
+@click.option(
+    "--esp-settings",
+    default="esp-settings.json",
+    type=click.Path(exists=True, dir_okay=False),
+    help="The path to the JSON serialized ESP calculation settings.",
+    show_default=True,
+)
+@click.option(
+    "--conf-settings",
+    default="conformer-settings.json",
+    type=click.Path(exists=True, dir_okay=False),
+    help="The path to the JSON serialized conformer generation settings.",
+    show_default=True,
+)
+@click.option(
+    "--n-procs",
+    "n_processors",
+    type=int,
+    default=1,
+    help="The number of processes to compute the ESP across.",
+    show_default=True,
+)
+def generate(smiles: str, esp_settings: str, conf_settings: str, n_processors: int):
+    esp_store = MoleculeESPStore()
+
+    # Load in the SMILES patterns to compute the ESP properties for.
+    with open(smiles) as file:
+        smiles = json.load(file)
+
+    # Load in the conformer generation and ESP settings.
+    esp_settings = ESPSettings.parse_file(esp_settings)
+    conformer_settings = ConformerSettings.parse_file(conf_settings)
+
+    with Pool(processes=n_processors) as pool:
+
+        esp_store.store(
+            *[
+                esp_record
+                for esp_records in pool.map(
+                    functools.partial(
+                        _compute_esp,
+                        conformer_settings=conformer_settings,
+                        settings=esp_settings,
+                    ),
+                    smiles,
+                )
+                for esp_record in esp_records
+            ]
+        )

--- a/openff/recharge/tests/cli/conftest.py
+++ b/openff/recharge/tests/cli/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.yield_fixture()
+def runner() -> CliRunner:
+    """Creates a new click CLI runner object and temporarily moves the working directory
+    to a temporary directory"""
+    click_runner = CliRunner()
+
+    with click_runner.isolated_filesystem():
+        yield click_runner

--- a/openff/recharge/tests/cli/test_generate.py
+++ b/openff/recharge/tests/cli/test_generate.py
@@ -1,0 +1,47 @@
+import json
+import os
+from multiprocessing.pool import Pool
+
+import numpy
+
+from openff.recharge.cli.generate import generate as generate_cli
+from openff.recharge.conformers import ConformerSettings
+from openff.recharge.esp import ESPSettings
+from openff.recharge.esp.psi4 import Psi4ESPGenerator
+from openff.recharge.esp.storage import MoleculeESPStore
+from openff.recharge.grids import GridSettings
+
+
+def test_generate(runner, monkeypatch):
+
+    # Mock the Psi4 calls so the test can run even when not present.
+    # This requires also mocking the multiprocessing to ensure the
+    # monkeypatch on Psi4 holds.
+    def mock_map(_, func, iterable):
+        return [func(x) for x in iterable]
+
+    def mock_psi4_generate(*_):
+        return numpy.zeros((1, 3)), numpy.zeros((1, 1)), numpy.zeros((1, 3))
+
+    monkeypatch.setattr(Psi4ESPGenerator, "generate", mock_psi4_generate)
+    monkeypatch.setattr(Pool, "map", mock_map)
+
+    # Create a mock set of inputs.
+    with open("smiles.json", "w") as file:
+        json.dump(["C"], file)
+
+    with open("esp-settings.json", "w") as file:
+        file.write(ESPSettings(grid_settings=GridSettings(spacing=1.0)).json())
+
+    with open("conformer-settings.json", "w") as file:
+        file.write(ConformerSettings(method="omega", sampling_mode="sparse").json())
+
+    result = runner.invoke(generate_cli)
+
+    if result.exit_code != 0:
+        raise result.exception
+
+    assert os.path.isfile("esp-store.sqlite")
+
+    esp_store = MoleculeESPStore()
+    assert len(esp_store.retrieve("C")) == 1

--- a/setup.py
+++ b/setup.py
@@ -44,16 +44,11 @@ setup(
     # Allows `setup.py test` to work correctly with pytest
     setup_requires=[] + pytest_runner,
 
-    # Additional entries you may want simply uncomment the lines you want and fill in the data
-    # url='http://www.my_package.com',  # Website
-    # install_requires=[],              # Required packages, pulls from pip if needed; do not use for Conda deployment
-    # platforms=['Linux',
-    #            'Mac OS-X',
-    #            'Unix',
-    #            'Windows'],            # Valid platforms your code works on, adjust to your flavor
-    # python_requires=">=3.5",          # Python version restrictions
-
-    # Manual control if final package is compressible or not, set False to prevent the .egg from being made
-    # zip_safe=False,
+    # Set up the main CLI entry points
+    entry_points={
+        'console_scripts': [
+            'recharge=openff.recharge.cli:cli',
+        ],
+    }
 
 )


### PR DESCRIPTION
## Description
This PR adds a new `recharge generate [OPTIONS] COMMAND [ARGS]` CLI command to generate ESP data for a set of smiles patterns based on settings defined in an `ESPSettings` JSON file and a `ConformerSettings` JSON file.

## Usage

```
% recharge --help
Usage: recharge [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  generate  Generate electrostatic property data for a set of SMILES.

% recharge generate --help
Usage: recharge generate [OPTIONS]

  Generate electrostatic property data for a set of SMILES.

Options:
  --smiles FILE         The path to a JSON file containing the set of SMILES
                        patterns.  [default: smiles.json]

  --esp-settings FILE   The path to the JSON serialized ESP calculation
                        settings.  [default: esp-settings.json]

  --conf-settings FILE  The path to the JSON serialized conformer generation
                        settings.  [default: conformer-settings.json]

  --n-procs INTEGER     The number of processes to compute the ESP across.
                        [default: 1]

  --help                Show this message and exit.

```

## Status
- [x] Ready to go