### PR TITLE
Adds Core Dependencies to Setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,28 @@ setup(
     # Allows `setup.py test` to work correctly with pytest
     setup_requires=[] + pytest_runner,
 
+    # Required packages, pulls from pip if needed; do not use for Conda deployment
+    install_requires=[
+        # Core dependencies
+        'click',
+        'numpy',
+        'pydantic',
+        # ESP generation
+        'jinja2',
+        # ESP storage
+        'sqlalchemy',
+        'sqlite',
+        # Python <3.8 compatibility
+        'typing-extensions'
+    ],
+
     # Set up the main CLI entry points
     entry_points={
         'console_scripts': [
             'recharge=openff.recharge.cli:cli',
         ],
-    }
+    },
 
+    # Python version restrictions
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
## Description
This PR adds the core dependencies to `setup.py` so that the base package (namely the data models) can be installed and used directly from `pip`.

## Status
- [x] Ready to go