### PR TITLE
Remove pin to older version of Psi4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
         shell: bash -l {0}
         run: |
 
-          conda install --yes -c conda-forge -c psi4/label/dev "psi4 <=1.4a2.dev215"
+          conda install --yes -c conda-forge -c psi4/label/dev psi4
 
       - name: Install Package
         shell: bash -l {0}


### PR DESCRIPTION
## Description
While preparing a report on Psi4 packaging issues, the local tests that previously demonstrated the issues are strangely now working. This PR reverts the pin to an on older version of Psi4 to see if CI now passes or if the solution is baked into some hysteresis in my local environment.