### PR TITLE
Add a Requires Package Utility Decorator

### DIFF
--- a/openff/recharge/smirnoff/smirnoff.py
+++ b/openff/recharge/smirnoff/smirnoff.py
@@ -9,7 +9,7 @@ from openff.recharge.smirnoff.exceptions import (
     UnsupportedBCCSmirksError,
     UnsupportedBCCValueError,
 )
-from openff.recharge.utilities.exceptions import MissingOptionalDependency
+from openff.recharge.utilities import requires_package
 
 if TYPE_CHECKING:
     from openforcefield.typing.engines.smirnoff.parameters import (
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     )
 
 
+@requires_package("openforcefield")
+@requires_package("simtk")
 def to_smirnoff(bcc_collection: BCCCollection) -> "ChargeIncrementModelHandler":
     """Converts a collection of bond charge correction parameters to
     a SMIRNOFF bond charge increment parameter handler.
@@ -42,13 +44,10 @@ def to_smirnoff(bcc_collection: BCCCollection) -> "ChargeIncrementModelHandler":
     -------
         The constructed parameter handler.
     """
-    try:
-        from openforcefield.typing.engines.smirnoff.parameters import (
-            ChargeIncrementModelHandler,
-        )
-        from simtk import unit
-    except ImportError:
-        raise MissingOptionalDependency("openforcefield")
+    from openforcefield.typing.engines.smirnoff.parameters import (
+        ChargeIncrementModelHandler,
+    )
+    from simtk import unit
 
     # noinspection PyTypeChecker
     bcc_parameter_handler = ChargeIncrementModelHandler(version="0.3")
@@ -70,6 +69,7 @@ def to_smirnoff(bcc_collection: BCCCollection) -> "ChargeIncrementModelHandler":
     return bcc_parameter_handler
 
 
+@requires_package("simtk")
 def from_smirnoff(
     parameter_handler: "ChargeIncrementModelHandler",
     aromaticity_model=AromaticityModels.MDL,
@@ -94,10 +94,7 @@ def from_smirnoff(
     -------
         The converted bond charge correction collection.
     """
-    try:
-        from simtk import unit
-    except ImportError:
-        raise MissingOptionalDependency("openforcefield")
+    from simtk import unit
 
     bcc_parameters = []
 

--- a/openff/recharge/tests/utilities/test_utilities.py
+++ b/openff/recharge/tests/utilities/test_utilities.py
@@ -2,7 +2,8 @@ import os
 
 import pytest
 
-from openff.recharge.utilities import get_data_file_path, temporary_cd
+from openff.recharge.utilities import get_data_file_path, requires_package, temporary_cd
+from openff.recharge.utilities.exceptions import MissingOptionalDependency
 
 
 def compare_paths(path_1: str, path_2: str) -> bool:
@@ -69,3 +70,18 @@ def test_temporary_cd():
         assert compare_paths(os.getcwd(), original_directory)
 
     assert compare_paths(os.getcwd(), original_directory)
+
+
+def test_requires_package():
+    """Tests that the ``requires_package`` utility behaves as expected."""
+
+    def dummy_function():
+        pass
+
+    # sys should always be found so this should not raise an exception.
+    requires_package("sys")(dummy_function)()
+
+    with pytest.raises(MissingOptionalDependency) as error_info:
+        requires_package("fake-lib")(dummy_function)()
+
+    assert error_info.value.library_name == "fake-lib"

--- a/openff/recharge/utilities/__init__.py
+++ b/openff/recharge/utilities/__init__.py
@@ -1,3 +1,7 @@
-from openff.recharge.utilities.utilities import get_data_file_path, temporary_cd
+from openff.recharge.utilities.utilities import (
+    get_data_file_path,
+    requires_package,
+    temporary_cd,
+)
 
-__all__ = [get_data_file_path, temporary_cd]
+__all__ = [get_data_file_path, requires_package, temporary_cd]


### PR DESCRIPTION
## Description
This PR adds a new `requires_package` decorator which raises a `MissingOptionalDependency` error when the required package is not found when calling the decorated function.

## Status
- [X] Ready to go