### PR TITLE
Automatically Remove Orphaned Provenance

### DIFF
--- a/openff/recharge/esp/storage/db.py
+++ b/openff/recharge/esp/storage/db.py
@@ -338,5 +338,9 @@ class DBInformation(DBBase):
 
     version = Column(Integer, primary_key=True)
 
-    general_provenance = relationship("DBGeneralProvenance")
-    software_provenance = relationship("DBSoftwareProvenance")
+    general_provenance = relationship(
+        "DBGeneralProvenance", cascade="all, delete-orphan"
+    )
+    software_provenance = relationship(
+        "DBSoftwareProvenance", cascade="all, delete-orphan"
+    )


### PR DESCRIPTION
## Description
This PR is an addition to #53 to ensure that 'orphaned' provenance information (i.e. entries which have been removed from the provenance dictionary) are automatically removed from the database.

## Status
- [X] Ready to go