### PR TITLE
Support SMIRNOFF BCCs with Implicit Reverse Value

### DIFF
--- a/openff/recharge/smirnoff/smirnoff.py
+++ b/openff/recharge/smirnoff/smirnoff.py
@@ -102,15 +102,19 @@ def from_smirnoff(
 
         smirks = off_parameter.smirks
 
-        if len(off_parameter.charge_increment) != 2:
+        if len(off_parameter.charge_increment) not in [1, 2]:
             raise UnsupportedBCCSmirksError(smirks, len(off_parameter.charge_increment))
 
         forward_value = off_parameter.charge_increment[0].value_in_unit(
             unit.elementary_charge
         )
-        reverse_value = off_parameter.charge_increment[1].value_in_unit(
-            unit.elementary_charge
-        )
+        reverse_value = -forward_value
+
+        if len(off_parameter.charge_increment) > 1:
+
+            reverse_value = off_parameter.charge_increment[1].value_in_unit(
+                unit.elementary_charge
+            )
 
         if not numpy.isclose(forward_value, -reverse_value):
 

--- a/openff/recharge/tests/smirnoff/test_smirnoff.py
+++ b/openff/recharge/tests/smirnoff/test_smirnoff.py
@@ -75,7 +75,7 @@ def test_collection_from_smirnoff():
         {"smirks": "[#6:1]-[#6:2]", "charge_increment": [-bcc_value, bcc_value]}
     )
     parameter_handler.add_parameter(
-        {"smirks": "[#1:1]-[#1:2]", "charge_increment": [bcc_value, -bcc_value]}
+        {"smirks": "[#1:1]-[#1:2]", "charge_increment": [bcc_value]}
     )
 
     bcc_collection = from_smirnoff(parameter_handler)


### PR DESCRIPTION
## Description
This PR adds support for SMIRNOFF BCCs where the reverse charge to apply is implicitly defined (see https://github.com/openforcefield/openff-toolkit/pull/726).

## Status
- [X] Ready to go