### PR TITLE
Revert gau2grid Pin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
         shell: bash -l {0}
         if: startsWith(matrix.os, 'ubuntu')
         run: |
-          conda install --yes -c defaults -c psi4/label/dev gau2grid ==2.0.3
+          conda install --yes -c defaults -c psi4/label/dev "gau2grid==2.0.3"
 
       - name: License OpenEye
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,12 @@ jobs:
           auto-activate-base: false
           show-channel-urls: true
 
+      - name: Pin gau2grid
+        shell: bash -l {0}
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          conda install --yes -c defaults -c psi4/label/dev gau2grid ==2.0.3
+
       - name: License OpenEye
         shell: bash -l {0}
         run: |

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -32,7 +32,6 @@ dependencies:
 
     # QCFractal integration.
   - qcfractal >=0.14.0  # - for testing only. Users only need qcportal.
-  - gau2grid ==2.0.3  # - for testing only with qcfractal.
   - qcportal
   - cmiles-base
 


### PR DESCRIPTION
## Description
This PR unpins the `gau2grid` package in the test environment as it seems to be causing the dependencies to be unresolvable on OSX, and instead only pins on Linux where the pin is needed.

## Status
- [x] Ready to go