### PR TITLE
Add 'autodiff-able' function to compute v-site positions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,15 +12,29 @@ on:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    name: Test on ${{ matrix.cfg.os }}, Python ${{ matrix.cfg.python-version }}
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.cfg.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
-        python-version: [3.8, 3.9]
+        cfg:
+          - python-version: 3.8
+            os: ubuntu-latest
+            env-file: "test-psi4"
+
+          - python-version: 3.9
+            os: ubuntu-latest
+            env-file: "test-psi4"
+
+          - python-version: 3.8
+            os: macos-latest
+            env-file: "test-torch"
+
+          - python-version: 3.9
+            os: macos-latest
+            env-file: "test-torch"
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
@@ -31,12 +45,10 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v2.1.1
         with:
-          python-version: ${{ matrix.python-version }}
-          environment-file: devtools/conda-envs/test_env.yaml
+          python-version: ${{ matrix.cfg.python-version }}
+          environment-file: devtools/conda-envs/${{ matrix.cfg.env-file }}.yaml
 
-          channels: conda-forge,psi4/label/dev,openeye,defaults
-
-          mamba-version: "*"
+          channels: conda-forge,defaults
 
           activate-environment: test
           auto-update-conda: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         cfg:
           - python-version: 3.8
-            os: ubuntu-latest
+            os: macos-latest
             env-file: "test-psi4"
 
           - python-version: 3.9
-            os: ubuntu-latest
+            os: macos-latest
             env-file: "test-psi4"
 
           - python-version: 3.8

--- a/devtools/conda-envs/test-psi4.yaml
+++ b/devtools/conda-envs/test-psi4.yaml
@@ -45,9 +45,6 @@ dependencies:
     # SMIRNOFF + v-site support
   - openff-toolkit-base
 
-    # Optimization
-  - pytorch-cpu
-
     # Linting
   - black
   - isort

--- a/devtools/conda-envs/test-torch.yaml
+++ b/devtools/conda-envs/test-torch.yaml
@@ -1,0 +1,47 @@
+name: test
+channels:
+  - conda-forge
+  - openeye
+  - defaults
+dependencies:
+    # Base depends
+  - python
+  - pip
+
+    # Testing
+  - pytest
+  - pytest-cov
+  - codecov
+
+    ### Core dependencies.
+
+  - click
+  - tqdm
+  - numpy
+  - jinja2
+  - pydantic
+  - openff-utilities
+  - openeye-toolkits
+
+    # ESP storage
+  - sqlalchemy
+  - sqlite
+
+    # Python < 3.8
+  - typing-extensions
+
+    ### Optional dependencies.
+
+    # SMIRNOFF + v-site support
+  - openff-toolkit-base
+
+    # Optimization
+  - pytorch-cpu
+
+    # Linting
+  - black
+  - isort
+  - flake8
+
+  - pip:
+      - git+git://github.com/openforcefield/openff-toolkit.git@param-iter

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -19,17 +19,22 @@ dependencies:
   - click
   - tqdm
   - numpy
+  - jinja2
   - pydantic
   - openff-utilities
   - openeye-toolkits
 
-    # ESP calculations
-  - jinja2
-  - psi4 >=1.4a3.dev1
-
     # ESP storage
   - sqlalchemy
   - sqlite
+
+    # Python < 3.8
+  - typing-extensions
+
+    ### Optional dependencies.
+
+    # ESP calculations
+  - psi4 >=1.4a3.dev1
 
     # QCFractal integration.
   - qcfractal >=0.15.6  # - for testing only. Users only need qcportal.
@@ -40,10 +45,8 @@ dependencies:
     # SMIRNOFF + v-site support
   - openff-toolkit-base
 
-    # Python < 3.8
-  - typing-extensions
-
-    ### Optional dependencies.
+    # Optimization
+  - pytorch-cpu
 
     # Linting
   - black

--- a/openff/recharge/tests/charges/test_vsite.py
+++ b/openff/recharge/tests/charges/test_vsite.py
@@ -504,6 +504,7 @@ def test_generator_local_coordinate_frames():
 @pytest.mark.parametrize("backend", ["numpy", "torch"])
 def test_generator_convert_local_coordinates(backend):
 
+    pytest.importorskip("torch")
     import torch
 
     local_frame_coordinates = numpy.array([[1.0, 45.0, 45.0]])

--- a/openff/recharge/tests/charges/test_vsite.py
+++ b/openff/recharge/tests/charges/test_vsite.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 
 import numpy
 import pytest
-import torch
 from openff.toolkit.topology import Molecule
 
 from openff.recharge.charges.exceptions import UnableToAssignChargeError
@@ -504,6 +503,8 @@ def test_generator_local_coordinate_frames():
 
 @pytest.mark.parametrize("backend", ["numpy", "torch"])
 def test_generator_convert_local_coordinates(backend):
+
+    import torch
 
     local_frame_coordinates = numpy.array([[1.0, 45.0, 45.0]])
     local_coordinate_frames = numpy.array(

--- a/openff/recharge/tests/charges/test_vsite.py
+++ b/openff/recharge/tests/charges/test_vsite.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 import numpy
 import pytest
+import torch
 from openff.toolkit.topology import Molecule
 
 from openff.recharge.charges.exceptions import UnableToAssignChargeError
@@ -14,7 +15,6 @@ from openff.recharge.charges.vsite import (
     VirtualSiteCollection,
     VirtualSiteGenerator,
 )
-from openff.recharge.conformers import ConformerGenerator, ConformerSettings
 from openff.recharge.tests import does_not_raise
 from openff.recharge.utilities.openeye import smiles_to_molecule
 
@@ -129,6 +129,80 @@ def vsite_force_field() -> "ForceField":
     )
 
     return force_field
+
+
+@pytest.mark.parametrize(
+    "parameter_type, n_positions",
+    [
+        (BondChargeSiteParameter, 2),
+        (MonovalentLonePairParameter, 3),
+        (DivalentLonePairParameter, 3),
+        (TrivalentLonePairParameter, 4),
+    ],
+)
+def test_local_frame_weights(parameter_type, n_positions):
+    assert parameter_type.local_frame_weights().shape == (3, n_positions)
+
+
+@pytest.mark.parametrize(
+    "parameter, expected_value",
+    [
+        (
+            BondChargeSiteParameter(
+                smirks="[*:1]-[*:2]",
+                name="EP",
+                charge_increments=(0.0, 0.0),
+                sigma=0.0,
+                epsilon=0.0,
+                match="once",
+                distance=2.0,
+            ),
+            numpy.array([[2.0, 180.0, 0.0]]),
+        ),
+        (
+            MonovalentLonePairParameter(
+                smirks="[*:1]-[*:2]-[*:3]",
+                name="EP",
+                charge_increments=(0.0, 0.0, 0.0),
+                sigma=0.0,
+                epsilon=0.0,
+                match="once",
+                distance=2.0,
+                in_plane_angle=30.0,
+                out_of_plane_angle=60.0,
+            ),
+            numpy.array([[2.0, 30.0, 60.0]]),
+        ),
+        (
+            DivalentLonePairParameter(
+                smirks="[*:1]-[*:2]-[*:3]",
+                name="EP",
+                charge_increments=(0.0, 0.0, 0.0),
+                sigma=0.0,
+                epsilon=0.0,
+                match="once",
+                distance=2.0,
+                out_of_plane_angle=60.0,
+            ),
+            numpy.array([[2.0, 180.0, 60.0]]),
+        ),
+        (
+            TrivalentLonePairParameter(
+                smirks="[*:1](-[*:2])(-[*:3])(-[*:4])",
+                name="EP",
+                charge_increments=(0.0, 0.0, 0.0),
+                sigma=0.0,
+                epsilon=0.0,
+                match="once",
+                distance=2.0,
+            ),
+            numpy.array([[2.0, 180.0, 0.0]]),
+        ),
+    ],
+)
+def test_local_frame_coordinates(parameter, expected_value):
+    assert parameter.local_frame_coordinates.shape == expected_value.shape
+    assert numpy.allclose(parameter.local_frame_coordinates, expected_value)
 
 
 @pytest.fixture(scope="module")
@@ -387,18 +461,96 @@ def test_generator_generate_charge_increments(
     assert numpy.allclose(actual_increments, expected_increments)
 
 
+def test_generator_local_coordinate_frames():
+
+    # Build a dummy 'formaldehyde' conformer and associated v-site parameter.
+    conformer = numpy.array(
+        [
+            [+1.0, +0.0, +0.0],
+            [+0.0, +0.0, +0.0],
+            [-1.0, +0.0, +1.0],
+            [-1.0, +0.0, -1.0],
+        ]
+    )
+    parameter = MonovalentLonePairParameter(
+        smirks="[O:1]=[C:2]-[H:3]",
+        name="EP",
+        charge_increments=(0.0, 0.0, 0.0),
+        sigma=0.0,
+        match="once",
+        epsilon=0.0,
+        distance=1.0,
+        in_plane_angle=180.0,
+        out_of_plane_angle=45.0,
+    )
+
+    assigned_parameters = {(0, 1, 2): [parameter], (0, 1, 3): [parameter]}
+
+    actual_coordinate_frames = VirtualSiteGenerator.build_local_coordinate_frames(
+        conformer, assigned_parameters
+    )
+    expected_coordinate_frames = numpy.array(
+        [
+            [[+1.0, +0.0, +0.0], [+1.0, +0.0, +0.0]],
+            [[-1.0, +0.0, +0.0], [-1.0, +0.0, +0.0]],
+            [[+0.0, +0.0, +1.0], [+0.0, +0.0, -1.0]],
+            [[+0.0, +1.0, +0.0], [+0.0, -1.0, +0.0]],
+        ]
+    )
+
+    assert actual_coordinate_frames.shape == (4, 2, 3)
+    assert numpy.allclose(actual_coordinate_frames, expected_coordinate_frames)
+
+
+@pytest.mark.parametrize("backend", ["numpy", "torch"])
+def test_generator_convert_local_coordinates(backend):
+
+    local_frame_coordinates = numpy.array([[1.0, 45.0, 45.0]])
+    local_coordinate_frames = numpy.array(
+        [
+            [[+0.0, +0.0, +0.0]],
+            [[+1.0, +0.0, +0.0]],
+            [[+0.0, +1.0, +0.0]],
+            [[+0.0, +0.0, +1.0]],
+        ]
+    )
+
+    if backend == "torch":
+        local_coordinate_frames = torch.from_numpy(local_coordinate_frames)
+        local_frame_coordinates = torch.from_numpy(local_frame_coordinates)
+
+    actual_coordinates = VirtualSiteGenerator.convert_local_coordinates(
+        local_frame_coordinates, local_coordinate_frames, backend
+    )
+
+    if backend == "numpy":
+        assert isinstance(actual_coordinates, numpy.ndarray)
+    else:
+        assert isinstance(actual_coordinates, torch.Tensor)
+        actual_coordinates = actual_coordinates.numpy()
+
+    expected_coordinates = numpy.array([[0.5, 0.5, 1.0 / numpy.sqrt(2.0)]])
+
+    assert actual_coordinates.shape == (1, 3)
+    assert numpy.allclose(actual_coordinates, expected_coordinates)
+
+
 def test_generator_generate_positions(vsite_collection):
 
     oe_molecule = smiles_to_molecule("N")
 
-    conformers = ConformerGenerator.generate(
-        oe_molecule,
-        ConformerSettings(method="omega", sampling_mode="sparse", max_conformers=1),
+    conformer = numpy.array(
+        [
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.5, 0.0, +numpy.sqrt(0.75)],
+            [0.5, 0.0, -numpy.sqrt(0.75)],
+        ]
     )
 
     vsite_position = VirtualSiteGenerator.generate_positions(
-        oe_molecule, vsite_collection, conformers[0]
+        oe_molecule, vsite_collection, conformer
     )
 
     assert vsite_position.shape == (1, 3)
-    assert not numpy.allclose(vsite_position, 0.0)
+    assert numpy.allclose(vsite_position, numpy.array([0.0, 6.0, 0.0]))

--- a/openff/recharge/tests/esp/test_qcarchive.py
+++ b/openff/recharge/tests/esp/test_qcarchive.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from qcfractal.interface.collections import Dataset
 
 
-@pytest.mark.skipif(sys.platform == "linux", reason="psi4 broken on GHA linux")
 @pytest.mark.parametrize("pcm_settings", [None, PCMSettings()])
 def test_retrieve_results(
     pcm_settings,
@@ -89,7 +88,6 @@ def test_missing_result(
         )
 
 
-@pytest.mark.skipif(sys.platform == "linux", reason="psi4 broken on GHA linux")
 def test_from_qcfractal_result(qc_server: "FractalSnowflake", qc_data_set: "Dataset"):
 
     qc_result = qc_server.client().query_results(id="1")[0]

--- a/openff/recharge/tests/esp/test_qcarchive.py
+++ b/openff/recharge/tests/esp/test_qcarchive.py
@@ -1,4 +1,3 @@
-import sys
 from json import JSONDecodeError
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
## Description

This PR adds an automatically differentiable, fully vectorised way (`VirtualSiteGenerator.convert_local_coordinates`) to compute the positions of virtual sites.

This PR will be followed by another that will add utilities to train the geometry (i.e. distance, in plane and out of plane angles) parameters of virtual sites alongside their charge increments.

@mattwthompson this may be of interest to you as you start to consider matrix representations of v-sites in `openff-interchange`.

## Status
- [X] Ready to go