### PR TITLE
Add convenience methods to vectorize collections

### DIFF
--- a/openff/recharge/charges/bcc.py
+++ b/openff/recharge/charges/bcc.py
@@ -164,6 +164,24 @@ class BCCCollection(BaseModel):
 
         return cls(parameters=bcc_parameters, aromaticity_model=aromaticity_model)
 
+    def vectorize(self, smirks: List[str]) -> numpy.ndarray:
+        """Returns a flat vector of the charge increment values associated with each
+        SMIRKS pattern in a specified list.
+
+        Parameters
+        ----------
+        smirks
+            A list of SMIRKS patterns corresponding to the BCC values to include
+            in the returned vector.
+
+        Returns
+        -------
+            A flat vector of charge increments with shape=(n_smirks, 1)
+        """
+
+        parameters = {parameter.smirks: parameter for parameter in self.parameters}
+        return numpy.array([[parameters[pattern].value] for pattern in smirks])
+
 
 class BCCGenerator:
     """A class for generating the bond charge corrections which should

--- a/openff/recharge/tests/charges/test_bcc.py
+++ b/openff/recharge/tests/charges/test_bcc.py
@@ -113,6 +113,23 @@ def test_from_smirnoff():
     assert numpy.isclose(bcc_collection.parameters[1].value, -0.1)
 
 
+def test_vectorize_collection():
+
+    bcc_collection = BCCCollection(
+        parameters=[
+            BCCParameter(smirks=f"[#{element}:1]-[#1:2]", value=value, provenance={})
+            for element, value in [(9, 1.0), (17, 2.0), (35, 3.0)]
+        ]
+    )
+
+    parameter_vector = bcc_collection.vectorize(
+        smirks=["[#9:1]-[#1:2]", "[#35:1]-[#1:2]"]
+    )
+
+    assert parameter_vector.shape == (2, 1)
+    assert numpy.allclose(parameter_vector, numpy.array([[1.0], [3.0]]))
+
+
 def test_build_assignment_matrix():
 
     oe_molecule = smiles_to_molecule("C")

--- a/openff/recharge/tests/charges/test_vsite.py
+++ b/openff/recharge/tests/charges/test_vsite.py
@@ -321,6 +321,45 @@ def test_smirnoff_parity(
     assert numpy.allclose(openff_charges, recharges)
 
 
+def test_vectorize_collection_charge_increments(vsite_collection):
+
+    parameter_vector = vsite_collection.vectorize_charge_increments(
+        parameter_keys=[
+            ("[#6:2]=[#8:1]", "BondCharge", "EP", 1),
+            ("[#1:1]-[#8X2H2+0:2]-[#1:3]", "DivalentLonePair", "EP", 0),
+            ("[#1:1][#7:2]([#1:3])[#1:4]", "TrivalentLonePair", "EP", 1),
+        ],
+    )
+    assert parameter_vector.shape == (3, 1)
+    assert numpy.allclose(parameter_vector, numpy.array([[0.1], [1.0552 * 0.5], [0.2]]))
+
+
+def test_vectorize_collection_coordinates(vsite_collection):
+
+    parameter_vector = vsite_collection.vectorize_coordinates(
+        parameter_keys=[
+            ("[#1:1][#7:2]([#1:3])[#1:4]", "TrivalentLonePair", "EP", "distance"),
+            (
+                "[#1:1]-[#8X2H2+0:2]-[#1:3]",
+                "MonovalentLonePair",
+                "EP",
+                "in_plane_angle",
+            ),
+            (
+                "[#1:1]-[#8X2H2+0:2]-[#1:3]",
+                "MonovalentLonePair",
+                "EP",
+                "out_of_plane_angle",
+            ),
+            ("[#6:2]=[#8:1]", "BondCharge", "EP", "distance"),
+        ],
+    )
+    assert parameter_vector.shape == (4, 1)
+    assert numpy.allclose(
+        parameter_vector, numpy.array([[5.0], [180.0], [90.0], [7.0]])
+    )
+
+
 def test_generator_apply_virtual_sites(vsite_collection):
 
     oe_molecule = smiles_to_molecule("N")


### PR DESCRIPTION
## Description

This PR adds convience methods to easily 'vectorize' BCC and virtual site collections into flat parameter vectors that can be easily used for training.

## Status
- [X] Ready to go