### PR TITLE
Add support for optimizing v-site coordinates

### DIFF
--- a/openff/recharge/charges/vsite.py
+++ b/openff/recharge/charges/vsite.py
@@ -26,7 +26,9 @@ ExclusionPolicy = Literal["none", "parents"]
 
 VirtualSiteKey = Tuple[str, str, str]
 VirtualSiteChargeKey = Tuple[str, str, str, int]
-VirtualSiteGeometryKey = Tuple[str, str, str, str]
+VirtualSiteGeometryKey = Tuple[
+    str, str, str, Literal["distance", "in_plane_angle", "out_of_plane_angle"]
+]
 
 _DEGREES_TO_RADIANS = numpy.pi / 180.0
 
@@ -76,7 +78,7 @@ class _VirtualSiteParameter(BaseModel, abc.ABC):
 
     @property
     @abc.abstractmethod
-    def local_frame_coordinates(cls) -> numpy.ndarray:
+    def local_frame_coordinates(self) -> numpy.ndarray:
         """Returns a 1 X 3 array of the spherical coordinates (``[d, theta, phi]``) of
         this virtual site with respect to its local frame.
         """

--- a/openff/recharge/optimize/__init__.py
+++ b/openff/recharge/optimize/__init__.py
@@ -1,3 +1,3 @@
-from openff.recharge.optimize.optimize import ElectricFieldOptimization, ESPOptimization
+from openff.recharge.optimize.optimize import ElectricFieldObjective, ESPObjective
 
-__all__ = [ElectricFieldOptimization, ESPOptimization]
+__all__ = [ElectricFieldObjective, ESPObjective]

--- a/openff/recharge/tests/optimize/test_optimize.py
+++ b/openff/recharge/tests/optimize/test_optimize.py
@@ -1,59 +1,301 @@
-from typing import List, Optional, Tuple
+from typing import Callable, Tuple, Type
 
 import numpy
 import pytest
+from typing_extensions import Literal
 
 from openff.recharge.charges.bcc import BCCCollection, BCCParameter
 from openff.recharge.charges.vsite import (
     BondChargeSiteParameter,
-    VirtualSiteChargeKey,
+    MonovalentLonePairParameter,
     VirtualSiteCollection,
 )
 from openff.recharge.esp import ESPSettings
 from openff.recharge.esp.storage import MoleculeESPRecord
 from openff.recharge.grids import GridSettings
-from openff.recharge.optimize import ESPOptimization
-from openff.recharge.optimize.optimize import ElectricFieldOptimization, _Optimization
-from openff.recharge.utilities.geometry import (
-    ANGSTROM_TO_BOHR,
-    INVERSE_ANGSTROM_TO_BOHR,
-    compute_vector_field,
+from openff.recharge.optimize import ESPObjective
+from openff.recharge.optimize.optimize import (
+    ElectricFieldObjective,
+    ElectricFieldObjectiveTerm,
+    ESPObjectiveTerm,
+    Objective,
+    ObjectiveTerm,
 )
+from openff.recharge.utilities.geometry import BOHR_TO_ANGSTROM
 from openff.recharge.utilities.openeye import smiles_to_molecule
 
+try:
+    import torch
+except ImportError:
+    torch = None
 
-def mock_esp_record(
-    smiles: str,
-    conformer: numpy.ndarray,
-    grid: numpy.ndarray,
-    esp_value: float,
-    ef_value: Tuple[float, float, float],
-) -> MoleculeESPRecord:
+backends = ["numpy"] + ([] if torch is None else ["torch"])
 
-    oe_molecule = smiles_to_molecule(smiles)
+
+@pytest.fixture()
+def hcl_esp_record() -> MoleculeESPRecord:
+
+    oe_molecule = smiles_to_molecule("[H]Cl")
 
     return MoleculeESPRecord.from_oe_molecule(
         oe_molecule,
-        conformer=conformer,
-        grid_coordinates=grid,
-        esp=numpy.array([[esp_value]] * len(grid)),
-        electric_field=numpy.array([ef_value] * len(grid)),
+        conformer=numpy.array([[-4, 0, 0], [0, 0, 0]]) * BOHR_TO_ANGSTROM,
+        grid_coordinates=numpy.array([[-4, 3, 0], [4, 3, 0]]) * BOHR_TO_ANGSTROM,
+        esp=numpy.array([[2.0], [2.0]]),
+        electric_field=numpy.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]),
         esp_settings=ESPSettings(grid_settings=GridSettings()),
     )
 
 
-def test_compute_esp_residuals():
+@pytest.fixture()
+def hcl_parameters() -> Tuple[BCCCollection, VirtualSiteCollection]:
 
-    v_difference = ESPOptimization.compute_residuals(
-        numpy.array([[1.0 / 5.0, 0.0], [0.0, 1.0 / 5.0]]),
-        numpy.array([[5.0], [10.0]]),
-        numpy.array([[1.0], [2.0]]),
+    bcc_collection = BCCCollection(
+        parameters=[
+            BCCParameter(smirks="[#17:1]-[#1:2]", value=-1.0, provenance={}),
+        ]
+    )
+    vsite_collection = VirtualSiteCollection(
+        parameters=[
+            BondChargeSiteParameter(
+                smirks="[#17:1]-[#1:2]",
+                name="EP",
+                distance=4.0 * BOHR_TO_ANGSTROM,
+                match="once",
+                charge_increments=(0.5, 0.1),
+                sigma=1.0,
+                epsilon=0.0,
+            ),
+        ]
+    )
+    return bcc_collection, vsite_collection
+
+
+@pytest.mark.parametrize(
+    "input_type, output_type, backend",
+    (
+        []
+        if torch is None
+        else [
+            (numpy.array, torch.Tensor, "torch"),
+            (torch.tensor, torch.Tensor, "torch"),
+            (numpy.array, numpy.ndarray, "numpy"),
+            (torch.tensor, numpy.ndarray, "numpy"),
+        ]
+    ),
+)
+def test_term_to_backend(
+    input_type: Callable, output_type: Type, backend: Literal["numpy", "torch"]
+):
+
+    objective_term = ESPObjectiveTerm(
+        atom_charge_design_matrix=input_type([[1.0, 2.0]]),
+        vsite_charge_assignment_matrix=input_type([[1], [-1]]),
+        vsite_fixed_charges=input_type([[1.0]]),
+        vsite_coord_assignment_matrix=input_type([[-1, 1, -1]]),
+        vsite_fixed_coords=input_type([[0.0, 0.0, 0.0]]),
+        vsite_local_coordinate_frame=input_type(
+            [[[0.0, 0.0, 0.0]], [[1.0, 0.0, 0.0]], [[0.0, 1.0, 0.0]], [[0.0, 0.0, 1.0]]]
+        ),
+        grid_coordinates=input_type([[0.0, 0.0, 0.0]]),
+        target_residuals=input_type([[0.0]]),
+    )
+    objective_term.to_backend(backend)
+
+    assert isinstance(objective_term.atom_charge_design_matrix, output_type)
+
+    assert isinstance(objective_term.vsite_charge_assignment_matrix, output_type)
+    assert isinstance(objective_term.vsite_fixed_charges, output_type)
+
+    assert isinstance(objective_term.vsite_coord_assignment_matrix, output_type)
+    assert isinstance(objective_term.vsite_fixed_coords, output_type)
+
+    assert isinstance(objective_term.grid_coordinates, output_type)
+    assert isinstance(objective_term.target_residuals, output_type)
+
+
+@pytest.mark.parametrize(
+    "term_class, design_matrix_precursor, expected_loss",
+    [
+        (
+            ESPObjectiveTerm,
+            # Assumes two atoms at (0,0,0) and (4,0,0) and one grid point at (0,3,0)
+            numpy.array([[1.0 / 3.0, 1.0 / 5.0]]),
+            # Target residual (1.0) - design matrix @ charges (2.0)
+            (1.0 - (2.0 / 3.0 - 2.0 / 5.0)) ** 2,
+        ),
+        (
+            ElectricFieldObjectiveTerm,
+            numpy.array(
+                [[[+0.0, -4.0 / 125.0], [+3.0 / 27.0, +3.0 / 125.0], [+0.0, +0.0]]]
+            ),
+            (
+                (1.0 - 2.0 * (0.0 - -4.0 / 125.0)) ** 2
+                + (1.0 - 2.0 * (3.0 / 27.0 - 3.0 / 125.0)) ** 2
+                + 1.0
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("backend", backends)
+def test_term_evaluate_bcc_only(
+    term_class: Type[ObjectiveTerm],
+    design_matrix_precursor: numpy.ndarray,
+    expected_loss: numpy.ndarray,
+    backend: Literal["numpy", "torch"],
+):
+
+    charge_values = (
+        numpy.array([[2.0]]) if backend == "numpy" else torch.tensor([[2.0]])
     )
 
-    assert numpy.allclose(v_difference, 0.0)
+    term = term_class(
+        atom_charge_design_matrix=design_matrix_precursor @ numpy.array([[1], [-1]]),
+        vsite_charge_assignment_matrix=None,
+        vsite_fixed_charges=None,
+        vsite_coord_assignment_matrix=None,
+        vsite_fixed_coords=None,
+        vsite_local_coordinate_frame=None,
+        grid_coordinates=None,
+        target_residuals=numpy.ones((1, 1 if design_matrix_precursor.ndim == 2 else 3)),
+    )
+    term.to_backend(backend)
+
+    output_loss = float(term.evaluate(charge_values, None))
+
+    assert numpy.isclose(expected_loss, output_loss)
 
 
-def test_compute_bcc_terms():
+@pytest.mark.parametrize(
+    "term_class, expected_loss",
+    [
+        # Assumes an atom at (0,0,0), v-site at (4,0,0) and a grid point at (0,3,0)
+        (
+            ESPObjectiveTerm,
+            # Target residual (1.0) - inverse distance @ charges (2.0)
+            (1.0 - 2.0 / 5.0) ** 2,
+        ),
+        (
+            ElectricFieldObjectiveTerm,
+            (
+                # Target residual (1.0) - vector field @ charges (2.0)
+                (1.0 - 2.0 * -4.0 / 125.0) ** 2
+                + (1.0 - 2.0 * 3.0 / 125.0) ** 2
+                + 1.0
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("backend", backends)
+def test_term_evaluate_vsite_only(
+    term_class: Type[ObjectiveTerm],
+    expected_loss: numpy.ndarray,
+    backend: Literal["numpy", "torch"],
+):
+
+    charge_values = (
+        numpy.array([[2.0]]) if backend == "numpy" else torch.tensor([[2.0]])
+    )
+    coordinate_values = (
+        numpy.array([[4.0 * BOHR_TO_ANGSTROM]])
+        if backend == "numpy"
+        else torch.tensor([[4.0 * BOHR_TO_ANGSTROM]])
+    )
+
+    term = term_class(
+        atom_charge_design_matrix=None,
+        vsite_charge_assignment_matrix=numpy.array([[-1.0]]),
+        # In practice this should be zero as there is only one charge increment and
+        # it is 'trainable', however for testing we give it a value to ensure this
+        # term is correctly included.
+        vsite_fixed_charges=numpy.array([[4.0]]),
+        vsite_coord_assignment_matrix=numpy.array([[0, -1, -1]]),
+        vsite_fixed_coords=numpy.array([[0.0, 180.0, 0.0]]),
+        vsite_local_coordinate_frame=numpy.array(
+            [
+                [[0.0, 0.0, 0.0]],
+                [[-1.0, 0.0, 0.0]],
+                [[0.0, 1.0, 0.0]],
+                [[0.0, 0.0, 1.0]],
+            ]
+        ),
+        grid_coordinates=numpy.array([[0.0, 3.0, 0.0]]) * BOHR_TO_ANGSTROM,
+        target_residuals=numpy.ones((1, 1 if term_class == ESPObjectiveTerm else 3)),
+    )
+    term.to_backend(backend)
+
+    output_loss = float(term.evaluate(charge_values, coordinate_values))
+
+    assert numpy.isclose(expected_loss, output_loss)
+
+
+@pytest.mark.parametrize(
+    "term_class, design_matrix_precursor, expected_loss",
+    [
+        # Assumes two atoms at (0,0,0) and (4,0,0), a v-site a (-4,0,0) and a grid point
+        # at (0,3,0). The first atom should receive a q=2.5, the second q=-2.0, and the
+        # v-site q=-0.5
+        (
+            ESPObjectiveTerm,
+            numpy.array([[1.0 / 3.0, 1.0 / 5.0]]),
+            # Target residual (1.0) - design matrix @ charges (2.0)
+            (1.0 - (2.5 / 3.0 - 2.0 / 5.0 - 0.5 / 5.0)) ** 2,
+        ),
+        (
+            ElectricFieldObjectiveTerm,
+            numpy.array([[[0.0, -4.0 / 125.0], [3.0 / 27.0, 3.0 / 125.0], [0.0, 0.0]]]),
+            (
+                (1.0 - (2.5 * 0.0 + -2.0 * -4.0 / 125.0 + -0.5 * 4.0 / 125.0)) ** 2
+                + (1.0 - (2.5 * 3.0 / 27.0 + -2.0 * 3.0 / 125.0 + -0.5 * 3.0 / 125.0))
+                ** 2
+                + 1.0
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("backend", backends)
+def test_term_evaluate_bcc_and_vsite(
+    term_class, design_matrix_precursor, expected_loss, backend
+):
+
+    charge_values = (
+        numpy.array([[2.0], [0.5]])
+        if backend == "numpy"
+        else torch.tensor([[2.0], [0.5]])
+    )
+
+    coordinate_values = (
+        numpy.array([[-4.0 * BOHR_TO_ANGSTROM]])
+        if backend == "numpy"
+        else torch.tensor([[-4.0 * BOHR_TO_ANGSTROM]])
+    )
+
+    term = term_class(
+        atom_charge_design_matrix=design_matrix_precursor
+        @ numpy.array([[1, 1], [-1, 0]]),
+        vsite_charge_assignment_matrix=numpy.array([[-1.0]]),
+        vsite_fixed_charges=numpy.array([[0.0]]),
+        vsite_coord_assignment_matrix=numpy.array([[0, -1, -1]]),
+        vsite_fixed_coords=numpy.array([[0.0, 180.0, 0.0]]),
+        vsite_local_coordinate_frame=numpy.array(
+            [
+                [[0.0, 0.0, 0.0]],
+                [[-1.0, 0.0, 0.0]],
+                [[0.0, 1.0, 0.0]],
+                [[0.0, 0.0, 1.0]],
+            ]
+        ),
+        grid_coordinates=numpy.array([[0.0, 3.0, 0.0]]) * BOHR_TO_ANGSTROM,
+        target_residuals=numpy.ones((1, 1 if term_class == ESPObjectiveTerm else 3)),
+    )
+    term.to_backend(backend)
+
+    output_loss = float(term.evaluate(charge_values, coordinate_values))
+
+    assert numpy.isclose(expected_loss, output_loss)
+
+
+def test_compute_bcc_charge_terms():
 
     oe_molecule = smiles_to_molecule("C#C")
 
@@ -64,7 +306,7 @@ def test_compute_bcc_terms():
         ]
     )
 
-    assignment_matrix, fixed_charges = _Optimization._compute_bcc_terms(
+    assignment_matrix, fixed_charges = Objective._compute_bcc_charge_terms(
         oe_molecule, bcc_collection, ["[#6:1]-[#1:2]"]
     )
 
@@ -77,7 +319,7 @@ def test_compute_bcc_terms():
     assert numpy.allclose(fixed_charges, numpy.array([[2], [-2], [0], [0]]))
 
 
-def test_compute_vsite_terms():
+def test_compute_vsite_charge_terms():
 
     oe_molecule = smiles_to_molecule("C#C")
 
@@ -104,7 +346,7 @@ def test_compute_vsite_terms():
         ]
     )
 
-    assignment_matrix, fixed_charges = _Optimization._compute_vsite_terms(
+    assignment_matrix, fixed_charges = Objective._compute_vsite_charge_terms(
         oe_molecule,
         vsite_collection,
         [
@@ -125,206 +367,203 @@ def test_compute_vsite_terms():
     )
 
 
-def test_vectorize_collections():
+def test_compute_vsite_coord_terms():
 
-    bcc_collection = BCCCollection(
-        parameters=[
-            BCCParameter(smirks=f"[#{element}:1]-[#1:2]", value=value, provenance={})
-            for element, value in [(9, 1.0), (17, 2.0), (35, 3.0)]
+    oe_molecule = smiles_to_molecule("C=O")
+
+    conformer = numpy.array(
+        [
+            [+1.0, +0.0, +0.0],
+            [+0.0, +0.0, +0.0],
+            [-1.0, +0.0, +1.0],
+            [-1.0, +0.0, -1.0],
         ]
     )
+
     vsite_collection = VirtualSiteCollection(
         parameters=[
-            BondChargeSiteParameter(
-                smirks=f"[#1:1]-[#{element}:2]",
+            MonovalentLonePairParameter(
+                smirks="[O:1]=[C:2]-[H:3]",
                 name="EP",
-                distance=-4.0,
+                charge_increments=(0.0, 0.0, 0.0),
+                sigma=0.0,
                 match="once",
-                charge_increments=values,
-                sigma=1.0,
                 epsilon=0.0,
+                distance=1.0,
+                in_plane_angle=180.0,
+                out_of_plane_angle=45.0,
             )
-            for element, values in [(9, (4.0, 5.0)), (17, (6.0, 7.0)), (35, (8.0, 9.0))]
         ]
     )
 
-    parameter_vector = _Optimization.vectorize_collections(
-        bcc_collection=bcc_collection,
-        trainable_bcc_parameters=["[#17:1]-[#1:2]"],
-        vsite_collection=vsite_collection,
-        trainable_vsite_parameters=[
-            ("[#1:1]-[#9:2]", "BondCharge", "EP", 1),
-            ("[#1:1]-[#35:2]", "BondCharge", "EP", 0),
+    assignment_matrix, fixed_coords, local_frame = Objective._compute_vsite_coord_terms(
+        oe_molecule,
+        conformer,
+        vsite_collection,
+        [
+            ("[O:1]=[C:2]-[H:3]", "MonovalentLonePair", "EP", "out_of_plane_angle"),
+            ("[O:1]=[C:2]-[H:3]", "MonovalentLonePair", "EP", "distance"),
         ],
     )
-    assert parameter_vector.shape == (3, 1)
-    assert numpy.allclose(parameter_vector, numpy.array([[2.0], [5.0], [8.0]]))
 
+    assert assignment_matrix.shape == (2, 3)
+    assert numpy.allclose(assignment_matrix, numpy.array([[1, -1, 0], [1, -1, 0]]))
 
-@pytest.mark.parametrize(
-    "bcc_collection, bcc_keys, vsite_collection, vsite_keys, expected_design_matrix, "
-    "expected_residuals",
-    [
-        (
-            BCCCollection(
-                parameters=[
-                    BCCParameter(smirks="[#17:1]-[#1:2]", value=1.0, provenance={}),
-                ]
-            ),
-            ["[#17:1]-[#1:2]"],
-            None,
-            [],
-            numpy.array([[-2.0 / 15.0], [2.0 / 15.0]]),
-            numpy.array([[2.0], [2.0]]),
-        ),
-        (
-            None,
-            [],
-            VirtualSiteCollection(
-                parameters=[
-                    BondChargeSiteParameter(
-                        smirks="[#1:1]-[#17:2]",
-                        name="EP",
-                        distance=-4.0,
-                        match="once",
-                        charge_increments=(0.0, 1.0),
-                        sigma=1.0,
-                        epsilon=0.0,
-                    ),
-                ]
-            ),
-            [("[#1:1]-[#17:2]", "BondCharge", "EP", i) for i in [0, 1]],
-            numpy.array([[2.0 / 15.0, 0.0], [-2.0 / 15.0, 0.0]]),
-            numpy.array([[2.0], [2.0]]),
-        ),
-    ],
-)
-def test_compute_esp_objective_terms(
-    bcc_collection: Optional[BCCCollection],
-    bcc_keys: List[str],
-    vsite_collection: Optional[VirtualSiteCollection],
-    vsite_keys: List[VirtualSiteChargeKey],
-    expected_design_matrix: numpy.ndarray,
-    expected_residuals: numpy.ndarray,
-):
-
-    esp_record = mock_esp_record(
-        "[H]Cl",
-        numpy.array([[-2, 0, 0], [2, 0, 0]]),
-        numpy.array([[-2, 3, 0], [2, 0, 3]]),
-        2.0,
-        (1.0, 1.0, 1.0),
-    )
-
-    objective_terms_generator = ESPOptimization.compute_objective_terms(
-        [esp_record],
-        None,
-        bcc_collection=bcc_collection,
-        trainable_bcc_parameters=bcc_keys,
-        vsite_collection=vsite_collection,
-        trainable_vsite_parameters=vsite_keys,
-    )
-    objective_terms = [*objective_terms_generator]
-
-    assert len(objective_terms) == 1
-    objective_term = objective_terms[0]
-
-    assert objective_term.design_matrix.shape == expected_design_matrix.shape
-
+    assert fixed_coords.shape == (2, 3)
     assert numpy.allclose(
-        objective_term.design_matrix / INVERSE_ANGSTROM_TO_BOHR,
-        expected_design_matrix,
+        fixed_coords, numpy.array([[0.0, 180.0, 0.0], [0.0, 180.0, 0.0]])
     )
 
-    assert objective_term.target_residuals.shape == expected_residuals.shape
-    assert numpy.allclose(objective_term.target_residuals, expected_residuals)
+    assert local_frame.shape == (4, 2, 3)
 
 
-@pytest.mark.parametrize(
-    "bcc_collection, bcc_keys, vsite_collection, vsite_keys, "
-    "expected_assignment_matrix, expected_residuals",
-    [
-        (
-            BCCCollection(
-                parameters=[
-                    BCCParameter(smirks="[#17:1]-[#1:2]", value=1.0, provenance={}),
-                ]
-            ),
-            ["[#17:1]-[#1:2]"],
-            None,
-            [],
-            numpy.array([[-1.0], [1.0]]),
-            numpy.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]),
-        ),
-        (
-            None,
-            [],
-            VirtualSiteCollection(
-                parameters=[
-                    BondChargeSiteParameter(
-                        smirks="[#1:1]-[#17:2]",
-                        name="EP",
-                        distance=-4.0,
-                        match="once",
-                        charge_increments=(0.0, 1.0),
-                        sigma=1.0,
-                        epsilon=0.0,
-                    ),
-                ]
-            ),
-            [("[#1:1]-[#17:2]", "BondCharge", "EP", i) for i in [0, 1]],
-            numpy.array([[1, 0], [0, 1], [-1, -1]]),
-            numpy.array([[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]]),
-        ),
-    ],
-)
-def test_compute_electric_field_objective_terms(
-    bcc_collection: Optional[BCCCollection],
-    bcc_keys: List[str],
-    vsite_collection: Optional[VirtualSiteCollection],
-    vsite_keys: List[VirtualSiteChargeKey],
-    expected_assignment_matrix: numpy.ndarray,
-    expected_residuals: numpy.ndarray,
-):
+def test_compute_esp_objective_terms(hcl_esp_record, hcl_parameters):
 
-    esp_record = mock_esp_record(
-        "[H]Cl",
-        numpy.array([[-2, 0, 0], [2, 0, 0]]),
-        numpy.array([[-2, 3, 0], [2, 0, 3]]),
-        2.0,
-        (1.0, 2.0, 3.0),
-    )
+    bcc_collection, vsite_collection = hcl_parameters
 
-    objective_terms_generator = ElectricFieldOptimization.compute_objective_terms(
-        [esp_record],
+    objective_terms_generator = ESPObjective.compute_objective_terms(
+        [hcl_esp_record],
         None,
         bcc_collection=bcc_collection,
-        trainable_bcc_parameters=bcc_keys,
+        bcc_parameter_keys=["[#17:1]-[#1:2]"],
         vsite_collection=vsite_collection,
-        trainable_vsite_parameters=vsite_keys,
+        vsite_charge_parameter_keys=[("[#17:1]-[#1:2]", "BondCharge", "EP", 0)],
+        vsite_coordinate_parameter_keys=[
+            ("[#17:1]-[#1:2]", "BondCharge", "EP", "distance")
+        ],
     )
     objective_terms = [*objective_terms_generator]
 
     assert len(objective_terms) == 1
     objective_term = objective_terms[0]
 
-    expected_vector_field = compute_vector_field(
-        (
-            esp_record.conformer
-            if vsite_collection is None
-            else (numpy.vstack([esp_record.conformer, numpy.array([[2, 0, 0]])]))
+    expected_design_matrix = numpy.array(
+        [
+            [1.0 / 5.0 - 1.0 / 3.0, 1.0 / 5.0],
+            [1.0 / 5.0 - 1.0 / numpy.sqrt(3.0 * 3.0 + 8.0 * 8.0), 1.0 / 5.0],
+        ]
+    )
+    assert (
+        objective_term.atom_charge_design_matrix.shape == expected_design_matrix.shape
+    )
+    assert numpy.allclose(
+        objective_term.atom_charge_design_matrix, expected_design_matrix
+    )
+
+    assert objective_term.vsite_charge_assignment_matrix.shape == (1, 1)
+    assert numpy.isclose(objective_term.vsite_charge_assignment_matrix, -1)
+
+    assert objective_term.vsite_fixed_charges.shape == (1, 1)
+    assert numpy.isclose(objective_term.vsite_fixed_charges, -0.1)
+
+    assert objective_term.vsite_coord_assignment_matrix.shape == (1, 3)
+    assert numpy.allclose(
+        objective_term.vsite_coord_assignment_matrix, numpy.array([[0, -1, -1]])
+    )
+
+    assert objective_term.vsite_fixed_coords.shape == (1, 3)
+    assert numpy.allclose(
+        objective_term.vsite_fixed_coords, numpy.array([[0.0, 180.0, 0.0]])
+    )
+
+    assert objective_term.vsite_local_coordinate_frame.shape == (4, 1, 3)
+
+    assert (
+        hcl_esp_record.grid_coordinates.shape == objective_term.grid_coordinates.shape
+    )
+    assert numpy.allclose(
+        hcl_esp_record.grid_coordinates, objective_term.grid_coordinates
+    )
+
+    assert objective_term.target_residuals.shape == (2, 1)
+    assert numpy.allclose(
+        objective_term.target_residuals,
+        numpy.array(
+            [[2.0 - (0.1 / 3.0)], [2.0 - (0.1 / numpy.sqrt(3.0 * 3.0 + 8.0 * 8.0))]]
+        ),
+    )
+
+
+def test_compute_field_objective_terms(hcl_esp_record, hcl_parameters):
+
+    bcc_collection, vsite_collection = hcl_parameters
+
+    objective_terms_generator = ElectricFieldObjective.compute_objective_terms(
+        [hcl_esp_record],
+        None,
+        bcc_collection=bcc_collection,
+        bcc_parameter_keys=["[#17:1]-[#1:2]"],
+        vsite_collection=vsite_collection,
+        vsite_charge_parameter_keys=[("[#17:1]-[#1:2]", "BondCharge", "EP", 0)],
+        vsite_coordinate_parameter_keys=[
+            ("[#17:1]-[#1:2]", "BondCharge", "EP", "distance")
+        ],
+    )
+    objective_terms = [*objective_terms_generator]
+
+    assert len(objective_terms) == 1
+    objective_term = objective_terms[0]
+
+    # Distance between H and the grid point at (4, 3, 0)
+    h_distance = numpy.sqrt(3.0 * 3.0 + 8.0 * 8.0)
+
+    expected_design_matrix = (
+        numpy.array(
+            [
+                [[0.0, -4.0 / 5.0 ** 3], [3.0 / 3.0 ** 3, 3.0 / 5.0 ** 3], [0.0, 0.0]],
+                [
+                    [8.0 / h_distance ** 3, 4.0 / 5.0 ** 3],
+                    [3.0 / h_distance ** 3, 3.0 / 5.0 ** 3],
+                    [0.0, 0.0],
+                ],
+            ]
         )
-        * ANGSTROM_TO_BOHR,
-        esp_record.grid_coordinates * ANGSTROM_TO_BOHR,
+        @ numpy.array([[-1, 0], [1, 1]])
     )
-    expected_design_matrix = expected_vector_field @ expected_assignment_matrix[:, :]
 
-    assert objective_term.design_matrix.shape == expected_design_matrix.shape
-
+    assert (
+        objective_term.atom_charge_design_matrix.shape == expected_design_matrix.shape
+    )
     assert numpy.allclose(
-        objective_term.design_matrix,
-        expected_design_matrix,
+        objective_term.atom_charge_design_matrix, expected_design_matrix
     )
 
-    assert objective_term.target_residuals.shape == expected_residuals.shape
-    assert numpy.allclose(objective_term.target_residuals, expected_residuals)
+    assert objective_term.vsite_charge_assignment_matrix.shape == (1, 1)
+    assert numpy.isclose(objective_term.vsite_charge_assignment_matrix, -1)
+
+    assert objective_term.vsite_fixed_charges.shape == (1, 1)
+    assert numpy.isclose(objective_term.vsite_fixed_charges, -0.1)
+
+    assert objective_term.vsite_coord_assignment_matrix.shape == (1, 3)
+    assert numpy.allclose(
+        objective_term.vsite_coord_assignment_matrix, numpy.array([[0, -1, -1]])
+    )
+
+    assert objective_term.vsite_fixed_coords.shape == (1, 3)
+    assert numpy.allclose(
+        objective_term.vsite_fixed_coords, numpy.array([[0.0, 180.0, 0.0]])
+    )
+
+    assert objective_term.vsite_local_coordinate_frame.shape == (4, 1, 3)
+
+    assert (
+        hcl_esp_record.grid_coordinates.shape == objective_term.grid_coordinates.shape
+    )
+    assert numpy.allclose(
+        hcl_esp_record.grid_coordinates, objective_term.grid_coordinates
+    )
+
+    assert objective_term.target_residuals.shape == (2, 3)
+    assert numpy.allclose(
+        objective_term.target_residuals,
+        numpy.array(
+            [
+                [1.0 - 0.0, 2.0 - 0.1 * 3.0 / 3.0 ** 3, 3.0 - 0.0],
+                [
+                    1.0 - 0.1 * 8.0 / h_distance ** 3,
+                    2.0 - 0.1 * 3.0 / h_distance ** 3,
+                    3.0 - 0.0,
+                ],
+            ]
+        ),
+    )

--- a/openff/recharge/tests/utilities/test_tensors.py
+++ b/openff/recharge/tests/utilities/test_tensors.py
@@ -40,9 +40,9 @@ def test_to_torch(tensor_type):
     pytest.importorskip("torch")
 
     input_tensor = tensor_type([[0.5, 1.0]])
-    output_tensor = to_torch(input_tensor).type(torch.float64)
+    output_tensor = to_torch(input_tensor)
 
-    expected_tensor = torch.tensor([[0.5, 1.0]], dtype=torch.float64)
+    expected_tensor = torch.tensor([[0.5, 1.0]])
 
     assert output_tensor.shape == expected_tensor.shape
     assert torch.allclose(output_tensor, expected_tensor)

--- a/openff/recharge/utilities/tensors.py
+++ b/openff/recharge/utilities/tensors.py
@@ -28,7 +28,7 @@ def to_numpy(tensor):
     if tensor is None:
         return None
 
-    if isinstance(tensor, numpy.ndarray):
+    elif isinstance(tensor, numpy.ndarray):
         return tensor
 
     return tensor.detach().numpy()
@@ -53,10 +53,15 @@ def to_torch(tensor):
     if tensor is None:
         return None
 
-    if isinstance(tensor, torch.Tensor):
+    elif isinstance(tensor, torch.Tensor):
         return tensor
 
-    return torch.from_numpy(tensor)
+    torch_tensor = torch.from_numpy(tensor)
+
+    if torch_tensor.dtype == torch.float64:
+        torch_tensor = torch_tensor.type(torch.float32)
+
+    return torch_tensor
 
 
 @overload


### PR DESCRIPTION
## Description

This PR extends #63 to allow the local frame coordinates (e.g. their distance, in-plane and out-of-plane angles) to be optimised alongside the charge increment parameters.

This PR will temporarily break the examples in the `scripts folder`. These will be split into a new directory and cleaned up in a separate PR however and so will not be updated here to stop this PR from growing too large.

## Status
- [ ] Ready to go