### PR TITLE
Add helper method to combine objective terms

### DIFF
--- a/openff/recharge/optimize/optimize.py
+++ b/openff/recharge/optimize/optimize.py
@@ -251,7 +251,7 @@ class ObjectiveTerm(abc.ABC):
 
         if (
             self.vsite_local_coordinate_frame is None
-            and vsite_coordinate_parameters is None
+            and vsite_coordinate_parameters is not None
         ):
 
             raise RuntimeError(

--- a/openff/recharge/tests/utilities/test_tensors.py
+++ b/openff/recharge/tests/utilities/test_tensors.py
@@ -4,6 +4,7 @@ import pytest
 from openff.recharge.utilities.tensors import (
     append_zero,
     cdist,
+    concatenate,
     inverse_cdist,
     pairwise_differences,
     to_numpy,
@@ -121,3 +122,23 @@ def test_append_zero(tensor_type):
 
     assert output_tensor.shape == expected_tensor.shape
     assert numpy.allclose(output_tensor, expected_tensor)
+
+
+@pytest.mark.parametrize("tensor_type", tensor_types)
+def test_concatenate(tensor_type):
+
+    input_tensors = [
+        tensor_type([[1.0, 2.0]]),
+        tensor_type([[3.0, 4.0]]),
+        tensor_type([[5.0, 6.0]]),
+    ]
+    output_tensor = concatenate(*input_tensors)
+
+    expected_tensor = numpy.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+
+    assert output_tensor.shape == expected_tensor.shape
+    assert numpy.allclose(output_tensor, expected_tensor)
+
+
+def test_concatenate_none():
+    assert concatenate(None, None) is None

--- a/openff/recharge/utilities/tensors.py
+++ b/openff/recharge/utilities/tensors.py
@@ -176,3 +176,36 @@ def append_zero(a):
         return torch.cat([a, torch.zeros(1, dtype=a.dtype)])
 
     raise NotImplementedError()
+
+
+@overload
+def concatenate(*arrays: None, dimension: int = 0) -> None:
+    ...
+
+
+@overload
+def concatenate(*arrays: numpy.ndarray, dimension: int = 0) -> numpy.ndarray:
+    ...
+
+
+@overload
+def concatenate(*arrays: "torch.Tensor", dimension: int = 0) -> "torch.Tensor":
+    ...
+
+
+def concatenate(*arrays, dimension: int = 0):
+    """Concatenate multiple arrays along a specified dimension."""
+
+    if len(arrays) == 0:
+        raise NotImplementedError()
+
+    if all(array is None for array in arrays):
+        return None
+    elif isinstance(arrays[0], numpy.ndarray):
+        return numpy.concatenate([*arrays], axis=dimension)
+    elif arrays[0].__module__.startswith("torch"):
+        import torch
+
+        return torch.cat([*arrays], dim=dimension)
+
+    raise NotImplementedError()


### PR DESCRIPTION
## Description

This PR adds an experimental method for combining multiple objective terms into a single object containing almost fully vectorised arrays.

The only part of the loss function evaluation that is not vectorised is computing the pairwise distances between the virtual sites and the grid points.

## Status
- [ ] Ready to go