### PR TITLE
Split `evaluate` term into `predict` and `loss`

### DIFF
--- a/examples/parameter-training/pytorch/train-parameters.py
+++ b/examples/parameter-training/pytorch/train-parameters.py
@@ -128,9 +128,7 @@ def main():
 
     for epoch in range(n_epochs + 1):
 
-        loss = objective_term.evaluate(
-            initial_charge_increments, initial_vsite_coordinates
-        )
+        loss = objective_term.loss(initial_charge_increments, initial_vsite_coordinates)
 
         # Add a light restraint to the v-site distance to stop it from becoming too
         # unphysical


### PR DESCRIPTION
## Description

This PR splits the `ObjectiveTerm.evaluate` function into a `predict` and `loss` function to make using custom loss functions easier.

## Status
- [X] Ready to go