### PR TITLE
Fix `numpy` example and add to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,12 @@ jobs:
         run: |
           pytest -v --cov=openff openff/recharge/tests/ --cov-report=xml
 
+      - name: Run NumPy example
+        shell: bash -l {0}
+        if: ${{ matrix.cfg.env-file == 'test-psi4' }}
+        run: |
+          python examples/parameter-training/numpy/train-bcc-parameters.py
+
       - name: CodeCov
         uses: codecov/codecov-action@v2.0.2
         with:

--- a/examples/parameter-training/numpy/train-bcc-parameters.py
+++ b/examples/parameter-training/numpy/train-bcc-parameters.py
@@ -69,7 +69,7 @@ def main():
     # Train the parameters.
     trained_values, *_ = numpy.linalg.lstsq(
         objective_term.atom_charge_design_matrix,
-        objective_term.target_residuals,
+        objective_term.reference_values,
         rcond=None,
     )
 


### PR DESCRIPTION
It seems that in #78 the renaming of `ObjectiveTerm.target_residuals` to `.reference_values` broke one of the examples. I've also added it to CI, given that it runs in a few seconds on my machine.

I haven't gone through the others since I'm unable to install everything (or at least Psi4 and PyTorch) into the same environment.
