### PR TITLE
Fix attaching units to `None` electric field from QCF

### DIFF
--- a/openff/recharge/esp/qcresults.py
+++ b/openff/recharge/esp/qcresults.py
@@ -210,11 +210,14 @@ def compute_esp(
     field = None
 
     if compute_field:
-        field = numpy.array(
-            psi4_calculator.compute_field_over_grid_in_memory(psi4_grid)
+
+        field = (
+            numpy.array(psi4_calculator.compute_field_over_grid_in_memory(psi4_grid))
+            * unit.hartree
+            / (unit.bohr * unit.e)
         )
 
-    return esp * unit.hartree / unit.e, field * unit.hartree / (unit.bohr * unit.e)
+    return esp * unit.hartree / unit.e, field
 
 
 @requires_package("cmiles")

--- a/openff/recharge/esp/storage/_storage.py
+++ b/openff/recharge/esp/storage/_storage.py
@@ -106,7 +106,7 @@ class MoleculeESPRecord(BaseModel):
         conformer: unit.Quantity,
         grid_coordinates: unit.Quantity,
         esp: unit.Quantity,
-        electric_field: unit.Quantity,
+        electric_field: Optional[unit.Quantity],
         esp_settings: ESPSettings,
     ) -> "MoleculeESPRecord":
         """Creates a new ``MoleculeESPRecord`` from an existing molecule

--- a/openff/recharge/tests/esp/test_qcresults.py
+++ b/openff/recharge/tests/esp/test_qcresults.py
@@ -14,7 +14,8 @@ from openff.recharge.grids import LatticeGridSettings
 pytest.importorskip("qcportal")
 
 
-def test_from_qcportal_results():
+@pytest.mark.parametrize("with_field", [False, True])
+def test_from_qcportal_results(with_field):
 
     from qcportal import FractalClient
     from qcportal.models import ObjectId
@@ -27,10 +28,15 @@ def test_from_qcportal_results():
         qc_molecule=qc_result.get_molecule(),
         qc_keyword_set=qc_keyword_set,
         grid_settings=LatticeGridSettings(spacing=2.0),
+        compute_field=with_field,
     )
 
     assert not numpy.allclose(esp_record.esp, 0.0, rtol=1.0e-9)
-    assert not numpy.allclose(esp_record.electric_field, 0.0, rtol=1.0e-9)
+    assert (
+        esp_record.electric_field is None
+        if not with_field
+        else not numpy.allclose(esp_record.electric_field, 0.0, rtol=1.0e-9)
+    )
 
 
 def test_missing_wavefunction():


### PR DESCRIPTION
## Description

This PR fixes a bug where units would be attached to the electric field computed from electric field data even when it was `None`.

## Status
- [X] Ready to go