### PR TITLE
Fix from QC molecule with undefined stereo

### DIFF
--- a/openff/recharge/esp/qcresults.py
+++ b/openff/recharge/esp/qcresults.py
@@ -272,7 +272,9 @@ def from_qcportal_results(
 
     # Convert the OE molecule to a QC molecule and extract the conformer of
     # interest.
-    molecule = Molecule.from_qcschema(qc_molecule.dict(encoding="json"))
+    molecule = Molecule.from_qcschema(
+        qc_molecule.dict(encoding="json"), allow_undefined_stereo=True
+    )
 
     conformers = extract_conformers(molecule)
     assert len(conformers) == 1


### PR DESCRIPTION
## Description

This PR fixes a bug when attempting to reconstruct the ESP around a molecule with 'undefined stereochemistry'.

## Status
- [X] Ready to go