### PR TITLE
Add option to minimize conformer with psi4

### DIFF
--- a/examples/parameter-training/numpy/train-bcc-parameters.py
+++ b/examples/parameter-training/numpy/train-bcc-parameters.py
@@ -33,8 +33,12 @@ def main():
 
         for conformer in tqdm(conformers):
 
-            grid, esp, electric_field = Psi4ESPGenerator.generate(
-                molecule=molecule, conformer=conformer, settings=qc_data_settings
+            conformer, grid, esp, electric_field = Psi4ESPGenerator.generate(
+                molecule=molecule,
+                conformer=conformer,
+                settings=qc_data_settings,
+                # Minimize the input conformer prior to evaluating the ESP / EF
+                minimize=True,
             )
             qc_data_record = MoleculeESPRecord.from_molecule(
                 molecule, conformer, grid, esp, electric_field, qc_data_settings

--- a/examples/parameter-training/pyro/train-parameters.py
+++ b/examples/parameter-training/pyro/train-parameters.py
@@ -28,8 +28,8 @@ def main():
     esp_settings = ESPSettings(
         method="hf", basis="6-31G*", grid_settings=LatticeGridSettings(spacing=0.7)
     )
-    grid, esp, electric_field = Psi4ESPGenerator.generate(
-        molecule=molecule, conformer=conformer, settings=esp_settings
+    conformer, grid, esp, electric_field = Psi4ESPGenerator.generate(
+        molecule=molecule, conformer=conformer, settings=esp_settings, minimize=True
     )
     esp_record = MoleculeESPRecord.from_molecule(
         molecule, conformer, grid, esp, electric_field, esp_settings

--- a/examples/parameter-training/pytorch/train-parameters.py
+++ b/examples/parameter-training/pytorch/train-parameters.py
@@ -37,8 +37,8 @@ def main():
         method="hf", basis="6-31G*", grid_settings=LatticeGridSettings(spacing=0.7)
     )
 
-    grid, esp, electric_field = Psi4ESPGenerator.generate(
-        molecule=molecule, conformer=conformer, settings=esp_settings
+    conformer, grid, esp, electric_field = Psi4ESPGenerator.generate(
+        molecule=molecule, conformer=conformer, settings=esp_settings, minimize=True
     )
     esp_record = MoleculeESPRecord.from_molecule(
         molecule, conformer, grid, esp, electric_field, esp_settings

--- a/examples/qc-data-generation/generate-psi4.py
+++ b/examples/qc-data-generation/generate-psi4.py
@@ -28,7 +28,7 @@ def main():
     # Generate a set of conformers for the molecule. We will compute the ESP and
     # electric field for the molecule in each conformer.
     conformers = ConformerGenerator.generate(
-        molecule, ConformerSettings(max_conformers=10)
+        molecule, ConformerSettings(max_conformers=1)
     )
 
     # Create a database to store the computed electrostatic properties in to make
@@ -40,8 +40,12 @@ def main():
 
     for conformer in tqdm(conformers):
 
-        grid, esp, electric_field = Psi4ESPGenerator.generate(
-            molecule, conformer, esp_settings
+        conformer, grid, esp, electric_field = Psi4ESPGenerator.generate(
+            molecule,
+            conformer,
+            esp_settings,
+            # Minimize the input conformer prior to evaluating the ESP / EF
+            minimize=True,
         )
 
         record = MoleculeESPRecord.from_molecule(

--- a/openff/recharge/data/psi4/input.dat
+++ b/openff/recharge/data/psi4/input.dat
@@ -42,4 +42,10 @@ pcm = {
 }
 {%- endif %}
 
+{%- if minimize %}
+
+optimize('scf')
+{%- endif %}
+
 E,wfn = prop('{%- if spin == 2 %}u{% endif %}{{ method }}', properties = ['GRID_ESP', 'GRID_FIELD'], return_wfn=True)
+mol.save_xyz_file('final-geometry.xyz',1)


### PR DESCRIPTION
## Description

This PR extends the `Psi4ESPGenerator.generate` function to accept a new `minimize` argument that instructs `psi4` to minimize the input conformer prior to computing the ESP / EF.

This change slightly break the API as the function will now return

```
conformer, grid, esp, electric_field
```

rather than

```
grid, esp, electric_field
```

## Status
- [X] Ready to go