### PR TITLE
Fix generating dummy RESP initial charges

### DIFF
--- a/openff/recharge/charges/resp/_resp.py
+++ b/openff/recharge/charges/resp/_resp.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import numpy
@@ -32,13 +31,8 @@ def _generate_dummy_values(smiles: str) -> List[float]:
     total_charge = molecule.total_charge.value_in_unit(simtk_unit.elementary_charge)
     per_atom_charge = total_charge / molecule.n_atoms
 
-    n_times_applied = defaultdict(int)
-
-    for map_index in molecule.properties["atom_map"].values():
-        n_times_applied[map_index - 1] += 1
-
-    values = [per_atom_charge / n_times_applied[i] for i in range(len(n_times_applied))]
-    return values
+    n_values = len(set(molecule.properties["atom_map"].values()))
+    return [per_atom_charge] * n_values
 
 
 def molecule_to_resp_library_charge(

--- a/openff/recharge/tests/charges/resp/test_resp.py
+++ b/openff/recharge/tests/charges/resp/test_resp.py
@@ -68,15 +68,32 @@ def mock_esp_records() -> List[MoleculeESPRecord]:
     [
         ("[Cl:1][H:2]", [0.0, 0.0]),
         ("[O-:1][H:2]", [-0.5, -0.5]),
-        ("[N+:1]([H:2])([H:2])([H:2])([H:2])", [0.2, 0.05]),
+        ("[N+:1]([H:2])([H:2])([H:2])([H:2])", [0.2, 0.2]),
         ("[N+:1]([H:2])([H:3])([H:4])([H:5])", [0.2, 0.2, 0.2, 0.2, 0.2]),
         ("[N+:1]([H:2])([H:2])[O-:3]", [0.0, 0.0, 0.0]),
+        (
+            "[H:1][c:9]1[c:10]([c:13]([c:16]2[c:15]([c:11]1[H:3])[c:12]([c:14]"
+            "([c:17]([n+:20]2[C:19]([H:8])([H:8])[H:8])[C:18]([H:7])([H:7])[H:7])"
+            "[H:6])[H:4])[H:5])[H:2]",
+            [1.0 / 24.0] * 20,
+        ),
     ],
 )
 def test_generate_dummy_values(smiles, expected_values):
 
+    from simtk import unit as simtk_unit
+
     actual_values = _generate_dummy_values(smiles)
     assert actual_values == expected_values
+
+    molecule = Molecule.from_smiles(smiles, allow_undefined_stereo=True)
+
+    total_charge = molecule.total_charge.value_in_unit(simtk_unit.elementary_charge)
+    sum_charge = sum(
+        actual_values[i - 1] for i in molecule.properties["atom_map"].values()
+    )
+
+    assert numpy.isclose(total_charge, sum_charge)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This PR fixes generating the initial dummy set of charges for a RESP parameter that should sum to the expected total charge of the molecule.

## Status
- [X] Ready to go