### PR TITLE
Fix generating AM1BCC charges using the `QCChargeGenerator`

### DIFF
--- a/openff/recharge/charges/qc.py
+++ b/openff/recharge/charges/qc.py
@@ -208,7 +208,7 @@ class QCChargeGenerator:
         if settings.theory == "am1" and settings.optimize and settings.symmetrize:
             charge_method = "am1-mulliken"
         elif settings.theory == "am1bcc" and settings.optimize and settings.symmetrize:
-            charge_method = "am1-mulliken"
+            charge_method = "am1bcc"
         elif (
             settings.theory == "am1bcc"
             and not settings.optimize


### PR DESCRIPTION
## Description

This PR fixes a copy-paste bug whereby 'am1' charges are returned by the `QCChargeGenerator` rather than `am1bcc` charges when using a method of `am1bcc`.

## Status
- [X] Ready to go