### PR TITLE
Fix exception when objective term matches no v-sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased](https://github.com/openforcefield/openff-recharge/tree/HEAD)
+
+[Full Changelog](https://github.com/openforcefield/openff-recharge/compare/0.3.2...HEAD)
+
+**Fixed bugs:**
+
+- Fix generating AM1BCC charges using the `QCChargeGenerator` [\#118](https://github.com/openforcefield/openff-recharge/pull/118) ([SimonBoothroyd](https://github.com/SimonBoothroyd))
+
 ## [0.3.2](https://github.com/openforcefield/openff-recharge/tree/0.3.2) (2022-04-22)
 
 [Full Changelog](https://github.com/openforcefield/openff-recharge/compare/0.3.1...0.3.2)

--- a/openff/recharge/optimize/_optimize.py
+++ b/openff/recharge/optimize/_optimize.py
@@ -296,7 +296,10 @@ class ObjectiveTerm(abc.ABC):
         else:
             atom_contribution = 0.0
 
-        if self.vsite_local_coordinate_frame is not None:
+        if (
+            self.vsite_local_coordinate_frame is not None
+            and self.vsite_local_coordinate_frame.shape[1] > 0
+        ):
 
             trainable_coordinates = append_zero(vsite_coordinate_parameters.flatten())[
                 self.vsite_coord_assignment_matrix

--- a/openff/recharge/optimize/_optimize.py
+++ b/openff/recharge/optimize/_optimize.py
@@ -549,6 +549,14 @@ class Objective(abc.ABC):
             molecule, vsite_collection
         )
 
+        if len(assigned_parameter_map) == 0:
+
+            return (
+                numpy.zeros((0, 3)),
+                numpy.zeros((0, 3)),
+                numpy.zeros((4, 0, 3)),
+            )
+
         assigned_parameters = defaultdict(list)
 
         for _, parameter_keys in assigned_parameter_map.items():

--- a/openff/recharge/tests/optimize/test_optimize.py
+++ b/openff/recharge/tests/optimize/test_optimize.py
@@ -594,6 +594,48 @@ def test_compute_esp_objective_terms(hcl_esp_record, hcl_parameters):
     )
 
 
+def test_compute_esp_objective_terms_no_v_site(hcl_esp_record, hcl_parameters):
+    """Test that ESP objective can still be built when no v-sites match the records."""
+
+    bcc_collection, _ = hcl_parameters
+    vsite_collection = VirtualSiteCollection(
+        parameters=[
+            BondChargeSiteParameter(
+                smirks="[#35:1]-[#1:2]",
+                name="EP",
+                distance=4.0 * BOHR_TO_ANGSTROM,
+                match="all-permutations",
+                charge_increments=(0.5, 0.1),
+                sigma=1.0,
+                epsilon=0.0,
+            ),
+        ]
+    )
+
+    objective_terms_generator = ESPObjective.compute_objective_terms(
+        [hcl_esp_record],
+        None,
+        bcc_collection=bcc_collection,
+        bcc_parameter_keys=["[#17:1]-[#1:2]"],
+        vsite_collection=vsite_collection,
+        vsite_charge_parameter_keys=[("[#35:1]-[#1:2]", "BondCharge", "EP", 0)],
+        vsite_coordinate_parameter_keys=[
+            ("[#35:1]-[#1:2]", "BondCharge", "EP", "distance")
+        ],
+    )
+    objective_terms = [*objective_terms_generator]
+
+    assert len(objective_terms) == 1
+    objective_term = objective_terms[0]
+
+    assert objective_term.vsite_charge_assignment_matrix.shape == (0, 1)
+    assert objective_term.vsite_fixed_charges.shape == (0, 1)
+
+    assert objective_term.vsite_coord_assignment_matrix.shape == (0, 3)
+    assert objective_term.vsite_fixed_coords.shape == (0, 3)
+    assert objective_term.vsite_local_coordinate_frame.shape == (4, 0, 3)
+
+
 def test_compute_field_objective_terms(hcl_esp_record, hcl_parameters):
 
     bcc_collection, vsite_collection = hcl_parameters

--- a/openff/recharge/tests/optimize/test_optimize.py
+++ b/openff/recharge/tests/optimize/test_optimize.py
@@ -635,6 +635,33 @@ def test_compute_esp_objective_terms_no_v_site(hcl_esp_record, hcl_parameters):
     assert objective_term.vsite_fixed_coords.shape == (0, 3)
     assert objective_term.vsite_local_coordinate_frame.shape == (4, 0, 3)
 
+    bcc_charge_parameters = bcc_collection.vectorize(["[#17:1]-[#1:2]"])
+    charge_parameters = numpy.vstack(
+        [
+            bcc_charge_parameters,
+            vsite_collection.vectorize_charge_increments(
+                [("[#35:1]-[#1:2]", "BondCharge", "EP", 0)]
+            ),
+        ]
+    )
+    coordinate_parameters = vsite_collection.vectorize_coordinates(
+        [("[#35:1]-[#1:2]", "BondCharge", "EP", "distance")]
+    )
+
+    loss = objective_term.loss(charge_parameters, coordinate_parameters)
+    loss_no_v_site = next(
+        iter(
+            ESPObjective.compute_objective_terms(
+                [hcl_esp_record],
+                None,
+                bcc_collection=bcc_collection,
+                bcc_parameter_keys=["[#17:1]-[#1:2]"],
+            )
+        )
+    ).loss(bcc_charge_parameters, None)
+
+    assert numpy.isclose(loss, loss_no_v_site)
+
 
 def test_compute_field_objective_terms(hcl_esp_record, hcl_parameters):
 


### PR DESCRIPTION
## Description

This PR fixes exceptions raised where a training set contains molecules to which no v-sites being trained would be applied.

## Status
- [X] Ready to go