### PR TITLE
`MissingOptionalDependency` -> `MissingOptionalDependencyError`

### DIFF
--- a/devtools/conda-envs/docs-env.yaml
+++ b/devtools/conda-envs/docs-env.yaml
@@ -13,7 +13,7 @@ dependencies:
   - numpy
   - jinja2
   - pydantic
-  - openff-utilities >=0.1.4
+  - openff-utilities >=0.1.5
   - openff-units
   - openff-toolkit-base >=0.10.2
 

--- a/devtools/conda-envs/docs-env.yaml
+++ b/devtools/conda-envs/docs-env.yaml
@@ -13,7 +13,7 @@ dependencies:
   - numpy
   - jinja2
   - pydantic
-  - openff-utilities
+  - openff-utilities >=0.1.4
   - openff-units
   - openff-toolkit-base >=0.10.2
 

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -21,7 +21,7 @@ dependencies:
   - numpy
   - jinja2
   - pydantic
-  - openff-utilities >=0.1.4
+  - openff-utilities >=0.1.5
   - openff-units
   - openff-toolkit-base >=0.10.5
 

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -21,7 +21,7 @@ dependencies:
   - numpy
   - jinja2
   - pydantic
-  - openff-utilities
+  - openff-utilities >=0.1.4
   - openff-units
   - openff-toolkit-base >=0.10.5
 

--- a/openff/recharge/utilities/toolkits.py
+++ b/openff/recharge/utilities/toolkits.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Dict, List, Tuple, cast
 import numpy
 from openff.toolkit.utils import ToolkitUnavailableException
 from openff.units import unit
-from openff.utilities import MissingOptionalDependency
+from openff.utilities import MissingOptionalDependencyError
 
 if TYPE_CHECKING:
     from openff.toolkit.topology import Molecule
@@ -146,7 +146,7 @@ def match_smirks(
         )
     except (
         ModuleNotFoundError,
-        MissingOptionalDependency,
+        MissingOptionalDependencyError,
         ToolkitUnavailableException,
     ):
         return _rd_match_smirks(
@@ -260,7 +260,7 @@ def apply_mdl_aromaticity_model(
         return _oe_apply_mdl_aromaticity_model(molecule)
     except (
         ModuleNotFoundError,
-        MissingOptionalDependency,
+        MissingOptionalDependencyError,
         ToolkitUnavailableException,
     ):
         return _rd_apply_mdl_aromaticity_model(molecule)


### PR DESCRIPTION
## Description
Sorry for the API break (it's just a deprecation, but I might as well fix it now)