### PR TITLE
Add link to OpenFF install guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,10 @@ ENV/
 # mkdocs documentation
 /site
 
+# Sphinx documentation
+docs/_build/
+docs/ref/api/
+
 # mypy
 .mypy_cache/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,10 @@ intersphinx_mapping = {
         None,
     ),
     "mdtraj": ("https://www.mdtraj.org/1.9.5/", None),
+    "openff.docs": (
+        "https://docs.openforcefield.org/en/stable/",
+        None,
+    ),
 }
 
 autosummary_generate = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ intersphinx_mapping = {
     ),
     "mdtraj": ("https://www.mdtraj.org/1.9.5/", None),
     "openff.docs": (
-        "https://docs.openforcefield.org/en/stable/",
+        "https://docs.openforcefield.org/en/latest/",
         None,
     ),
 }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,6 +12,8 @@ The recommended way to install `openff-recharge` is via the `conda` package mana
 conda install -c conda-forge openff-recharge
 ```
 
+If you do not have Mamba installed, see the [OpenFF installation documentation](openff.docs:install).
+
 ### Optional dependencies
 
 #### OpenEye toolkits


### PR DESCRIPTION
Adds a link to the [ecosystem install guide](https://docs.openforcefield.org/en/latest/install.html) to the project install guide

## Status
- [x] Ready to go
