### PR TITLE
Update virtual sites to 0.11+

### DIFF
--- a/openff/recharge/charges/vsite.py
+++ b/openff/recharge/charges/vsite.py
@@ -499,9 +499,9 @@ class VirtualSiteGenerator:
 
         _, all_vsite_keys = cls._build_charge_increment_array(vsite_collection)
 
-        n_particles = max(
-            smirnoff_vsite_collection.virtual_site_key_topology_index_map.values()
-        ) + 1
+        vsite_to_index = smirnoff_vsite_collection.virtual_site_key_topology_index_map
+        n_particles = molecule.n_atoms + len(vsite_to_index)
+        
         n_corrections = len(all_vsite_keys)
         assignment_matrix = numpy.zeros((n_particles, n_corrections))
 

--- a/openff/recharge/charges/vsite.py
+++ b/openff/recharge/charges/vsite.py
@@ -384,7 +384,7 @@ class VirtualSiteCollection(BaseModel):
 
 class VirtualSiteGenerator:
     @classmethod
-    def _apply_virtual_sites(
+    def _create_virtual_site_collection(
         cls, molecule: "Molecule", vsite_collection: VirtualSiteCollection
     ) -> "SMIRNOFFVirtualSiteCollection":
         """Applies a virtual site collection to a molecule.
@@ -489,7 +489,7 @@ class VirtualSiteGenerator:
             where ...
         """
 
-        smirnoff_vsite_collection = cls._apply_virtual_sites(
+        smirnoff_vsite_collection = cls._create_virtual_site_collection(
             molecule, vsite_collection
         )
 
@@ -762,7 +762,7 @@ class VirtualSiteGenerator:
         }
 
         # Extract the values of the assigned parameters.
-        smirnoff_vsite_collection = cls._apply_virtual_sites(
+        smirnoff_vsite_collection = cls._create_virtual_site_collection(
             molecule, vsite_collection
         )
         assigned_parameters = defaultdict(list)

--- a/openff/recharge/charges/vsite.py
+++ b/openff/recharge/charges/vsite.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from openff.toolkit import Molecule
     from openff.toolkit.typing.engines.smirnoff import VirtualSiteHandler
+    from openff.interchange.smirnoff._virtual_sites import SMIRNOFFVirtualSiteCollection
 
 ExclusionPolicy = Literal["none", "parents"]
 
@@ -386,7 +387,7 @@ class VirtualSiteGenerator:
     @classmethod
     def _apply_virtual_sites(
         cls, molecule: "Molecule", vsite_collection: VirtualSiteCollection
-    ) -> Tuple["Molecule", Dict[int, Dict[VirtualSiteKey, List[Tuple[int, ...]]]]]:
+    ) -> "SMIRNOFFVirtualSiteCollection":
         """Applies a virtual site collection to a molecule.
 
         Parameters
@@ -398,42 +399,20 @@ class VirtualSiteGenerator:
 
         Returns
         -------
-            An OpenFF molecule with virtual sites as well as a dictionary that maps each
-            virtual site back to the parameter that yielded it.
+            An SMIRNOFFVirtualSiteCollection with keys stored in `.key_map`.
         """
+        from openff.interchange.smirnoff._virtual_sites import SMIRNOFFVirtualSiteCollection
 
         parameter_handler = vsite_collection.to_smirnoff()
 
-        off_topology = copy.deepcopy(molecule).to_topology()
-        parameter_handler.create_openff_virtual_sites(off_topology)
+        collection = SMIRNOFFVirtualSiteCollection()
+        collection.exclusion_policy = parameter_handler.exclusion_policy
+        collection.store_matches(
+            parameter_handler=parameter_handler,
+            topology=molecule.to_topology(),
+        )
+        return collection
 
-        vsite_matches = parameter_handler.find_matches(off_topology)
-        assigned_vsite_keys = defaultdict(lambda: defaultdict(list))
-
-        for vsite_match in vsite_matches:
-            vsite_parameter = vsite_match.parameter_type
-            vsite_key = (
-                vsite_parameter.smirks,
-                vsite_parameter.type,
-                vsite_parameter.name,
-            )
-
-            parent_atom_index = vsite_match.environment_match.reference_atom_indices[
-                vsite_parameter.parent_index
-            ]
-
-            assigned_vsite_keys[parent_atom_index][vsite_key].append(
-                vsite_match.environment_match.reference_atom_indices
-            )
-
-        off_molecule = next(off_topology.reference_molecules)
-
-        return off_molecule, {
-            parent_atom_index: {
-                key: [*orientations] for key, orientations in keys.items()
-            }
-            for parent_atom_index, keys in assigned_vsite_keys.items()
-        }
 
     @classmethod
     def _build_charge_increment_array(
@@ -514,40 +493,26 @@ class VirtualSiteGenerator:
 
         from openff.toolkit.typing.engines.smirnoff import VirtualSiteHandler
 
-        off_molecule, assigned_vsite_keys = cls._apply_virtual_sites(
+        smirnoff_vsite_collection = cls._apply_virtual_sites(
             molecule, vsite_collection
         )
 
         _, all_vsite_keys = cls._build_charge_increment_array(vsite_collection)
 
-        n_particles = off_molecule.n_particles
+        n_particles = max(
+            smirnoff_vsite_collection.virtual_site_key_topology_index_map.values()
+        ) + 1
         n_corrections = len(all_vsite_keys)
-
         assignment_matrix = numpy.zeros((n_particles, n_corrections))
 
-        for vsite_particle in [
-            vsite_particle
-            for vsite in off_molecule.virtual_sites
-            for vsite_particle in vsite.particles
-        ]:
-            vsite_index = vsite_particle.molecule_particle_index
-
-            type_parent_index = VirtualSiteHandler.VirtualSiteType.type_to_parent_index(
-                vsite_particle.virtual_site.type
-            )
-            parent_atom_index = vsite_particle.orientation[type_parent_index]
-
-            vsite_parameter_keys = assigned_vsite_keys[parent_atom_index]
-
-            for vsite_parameter_key in vsite_parameter_keys:
-                for i, atom_index in enumerate(vsite_particle.orientation):
-                    # noinspection PyTypeChecker
-                    vsite_parameter_index = all_vsite_keys.index(
-                        (*vsite_parameter_key, i)
-                    )
-
-                    assignment_matrix[atom_index, vsite_parameter_index] += 1
-                    assignment_matrix[vsite_index, vsite_parameter_index] -= 1
+        for vsite_key, potential_key in smirnoff_vsite_collection.key_map.items():
+            smirks = potential_key.id.split(" ")[0]
+            vsite_index = smirnoff_vsite_collection.virtual_site_key_topology_index_map[vsite_key]
+            for i, atom_index in enumerate(vsite_key.orientation_atom_indices):
+                key = (smirks, vsite_key.type, vsite_key.name, i)
+                vsite_parameter_index = all_vsite_keys.index(key)
+                assignment_matrix[atom_index, vsite_parameter_index] += 1
+                assignment_matrix[vsite_index, vsite_parameter_index] -= 1
 
         cls._validate_charge_assignment_matrix(assignment_matrix)
         return assignment_matrix
@@ -801,12 +766,15 @@ class VirtualSiteGenerator:
         }
 
         # Extract the values of the assigned parameters.
-        _, assigned_parameter_map = cls._apply_virtual_sites(molecule, vsite_collection)
+        smirnoff_vsite_collection = cls._apply_virtual_sites(
+            molecule, vsite_collection
+        )
         assigned_parameters = defaultdict(list)
 
-        for _, parameter_keys in assigned_parameter_map.items():
-            for parameter_key, orientations in parameter_keys.items():
-                assigned_parameters[parameter_key].extend(orientations)
+        for vsite_key, potential_key in smirnoff_vsite_collection.key_map.items():
+            smirks = potential_key.id.split(" ")[0]
+            key = (smirks, vsite_key.type, vsite_key.name)
+            assigned_parameters[key].append(vsite_key.orientation_atom_indices)
 
         assigned_parameters = [
             (vsite_parameters_by_key[parameter_key], orientations)

--- a/openff/recharge/charges/vsite.py
+++ b/openff/recharge/charges/vsite.py
@@ -1,9 +1,8 @@
 """Generate virtual sites for molecules from a collection of virtual site parameters."""
 
 import abc
-import copy
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union, overload
+from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, Union, overload
 
 import numpy
 from openff.units import unit
@@ -413,7 +412,6 @@ class VirtualSiteGenerator:
         )
         return collection
 
-
     @classmethod
     def _build_charge_increment_array(
         cls, vsite_collection: VirtualSiteCollection
@@ -491,8 +489,6 @@ class VirtualSiteGenerator:
             where ...
         """
 
-        from openff.toolkit.typing.engines.smirnoff import VirtualSiteHandler
-
         smirnoff_vsite_collection = cls._apply_virtual_sites(
             molecule, vsite_collection
         )
@@ -501,13 +497,13 @@ class VirtualSiteGenerator:
 
         vsite_to_index = smirnoff_vsite_collection.virtual_site_key_topology_index_map
         n_particles = molecule.n_atoms + len(vsite_to_index)
-        
+
         n_corrections = len(all_vsite_keys)
         assignment_matrix = numpy.zeros((n_particles, n_corrections))
 
         for vsite_key, potential_key in smirnoff_vsite_collection.key_map.items():
             smirks = potential_key.id.split(" ")[0]
-            vsite_index = smirnoff_vsite_collection.virtual_site_key_topology_index_map[vsite_key]
+            vsite_index = vsite_to_index[vsite_key]
             for i, atom_index in enumerate(vsite_key.orientation_atom_indices):
                 key = (smirks, vsite_key.type, vsite_key.name, i)
                 vsite_parameter_index = all_vsite_keys.index(key)

--- a/openff/recharge/optimize/_optimize.py
+++ b/openff/recharge/optimize/_optimize.py
@@ -582,7 +582,7 @@ class Objective(abc.ABC):
                     local_indices.append(-1)
             local_coordinate_parameters.append(local_parameters)
             local_coordinate_indices.append(local_indices)
-            
+
         assigned_parameters = [
             (parameters_by_key[parameter_key], orientations)
             for parameter_key, orientations in assigned_parameters.items()

--- a/openff/recharge/optimize/_optimize.py
+++ b/openff/recharge/optimize/_optimize.py
@@ -548,7 +548,7 @@ class Objective(abc.ABC):
             for parameter in vsite_collection.parameters
         }
 
-        smirnoff_vsite_collection = VirtualSiteGenerator._apply_virtual_sites(
+        smirnoff_vsite_collection = VirtualSiteGenerator._create_virtual_site_collection(
             molecule, vsite_collection
         )
 

--- a/openff/recharge/tests/charges/test_vsite.py
+++ b/openff/recharge/tests/charges/test_vsite.py
@@ -362,9 +362,6 @@ class TestVirtualSiteCollection:
         )
 
 
-# @pytest.mark.skip(
-#     reason="Virtual site code has not yet been refactored for version 0.11.0"
-# )
 class TestVirtualSiteGenerator:
     def test_apply_virtual_sites(self, vsite_collection):
         molecule = smiles_to_molecule("N")

--- a/openff/recharge/tests/charges/test_vsite.py
+++ b/openff/recharge/tests/charges/test_vsite.py
@@ -119,6 +119,7 @@ def vsite_force_field() -> "ForceField":
 
     return force_field
 
+
 @pytest.fixture(scope="module")
 def full_vsite_force_field(vsite_force_field: "ForceField") -> "ForceField":
     ff = copy.deepcopy(vsite_force_field)
@@ -211,7 +212,6 @@ class TestVirtualSiteParameter:
     def test_local_frame_coordinates(self, parameter, expected_value):
         assert parameter.local_frame_coordinates.shape == expected_value.shape
         assert numpy.allclose(parameter.local_frame_coordinates, expected_value)
-
 
 
 class TestVirtualSiteCollection:

--- a/openff/recharge/tests/charges/test_vsite.py
+++ b/openff/recharge/tests/charges/test_vsite.py
@@ -363,10 +363,10 @@ class TestVirtualSiteCollection:
 
 
 class TestVirtualSiteGenerator:
-    def test_apply_virtual_sites(self, vsite_collection):
+    def test_create_virtual_site_collection(self, vsite_collection):
         molecule = smiles_to_molecule("N")
 
-        smirnoff_virtual_site_collection = VirtualSiteGenerator._apply_virtual_sites(
+        smirnoff_virtual_site_collection = VirtualSiteGenerator._create_virtual_site_collection(
             molecule, vsite_collection
         )
 

--- a/openff/recharge/tests/charges/test_vsite.py
+++ b/openff/recharge/tests/charges/test_vsite.py
@@ -38,7 +38,10 @@ def _vsite_handler_to_string(vsite_handler: "VirtualSiteHandler") -> str:
 
             if not isinstance(attribute, unit.Quantity):
                 continue
-
+            if attribute.units == unit.radians:
+                attribute = attribute.to(unit.degrees)
+            elif attribute.units == unit.nanometers:
+                attribute = attribute.to(unit.angstrom)
             setattr(parameter, attribute_name, attribute)
 
     return force_field.to_string("XML")
@@ -64,7 +67,7 @@ def vsite_force_field() -> "ForceField":
             "charge_increment1": 0.2 * unit.elementary_charge,
             "charge_increment2": 0.1 * unit.elementary_charge,
             "sigma": 1.0 * unit.angstrom,
-            "epsilon": 2.0 / 4.184 * unit.kilocalorie_per_mole,
+            "epsilon": 2.0 * unit.kilojoules_per_mole,
         }
     )
     vsite_handler.add_parameter(
@@ -79,7 +82,7 @@ def vsite_force_field() -> "ForceField":
             "charge_increment1": 0.0 * unit.elementary_charge,
             "charge_increment2": 1.0552 * 0.5 * unit.elementary_charge,
             "charge_increment3": 1.0552 * 0.5 * unit.elementary_charge,
-            "sigma": 0.0 * unit.nanometers,
+            "sigma": 0.0 * unit.angstrom,
             "epsilon": 0.5 * unit.kilojoules_per_mole,
         }
     )
@@ -116,15 +119,26 @@ def vsite_force_field() -> "ForceField":
 
     return force_field
 
+@pytest.fixture(scope="module")
+def full_vsite_force_field(vsite_force_field: "ForceField") -> "ForceField":
+    ff = copy.deepcopy(vsite_force_field)
+    ff.get_parameter_handler("Electrostatics")
+    vdw = ff.get_parameter_handler("vdW")
+    vdw.add_parameter(
+        parameter_kwargs={
+            "smirks": "[*:1]",
+            "sigma": 1.0 * unit.angstrom,
+            "epsilon": 0 * unit.kilojoules_per_mole,
+        }
+    )
+    return ff
+
 
 @pytest.fixture(scope="module")
 def vsite_collection(vsite_force_field: "ForceField") -> VirtualSiteCollection:
     return VirtualSiteCollection.from_smirnoff(vsite_force_field["VirtualSites"])
 
 
-@pytest.mark.skip(
-    reason="Virtual site code has not yet been refactored for version 0.11.0"
-)
 class TestVirtualSiteParameter:
     @pytest.mark.parametrize(
         "parameter_type, n_positions",
@@ -199,9 +213,7 @@ class TestVirtualSiteParameter:
         assert numpy.allclose(parameter.local_frame_coordinates, expected_value)
 
 
-@pytest.mark.skip(
-    reason="Virtual site code has not yet been refactored for version 0.11.0"
-)
+
 class TestVirtualSiteCollection:
     def test_to_smirnoff(
         self, vsite_force_field: "ForceField", vsite_collection: VirtualSiteCollection
@@ -209,7 +221,6 @@ class TestVirtualSiteCollection:
         """Test that a collection of v-site parameters can be mapped to a SMIRNOFF
         `VirtualSiteHandler`.
         """
-
         expected_xml = _vsite_handler_to_string(vsite_force_field["VirtualSites"])
 
         smirnoff_handler = vsite_collection.to_smirnoff()
@@ -280,13 +291,17 @@ class TestVirtualSiteCollection:
         assert numpy.isclose(trivalent.epsilon, 0.5)
 
     def test_smirnoff_parity(
-        self, vsite_force_field: "ForceField", vsite_collection: VirtualSiteCollection
+        self, full_vsite_force_field: "ForceField", vsite_collection: VirtualSiteCollection
     ):
         import openmm.unit
 
         molecule = smiles_to_molecule("N")
+        molecule.assign_partial_charges("zeros")
 
-        openmm_system = vsite_force_field.create_openmm_system(molecule.to_topology())
+        openmm_system = full_vsite_force_field.create_openmm_system(
+            molecule.to_topology(),
+            charge_from_molecules=[molecule]
+        )
         openmm_force = [
             force
             for force in openmm_system.getForces()
@@ -347,29 +362,24 @@ class TestVirtualSiteCollection:
         )
 
 
-@pytest.mark.skip(
-    reason="Virtual site code has not yet been refactored for version 0.11.0"
-)
+# @pytest.mark.skip(
+#     reason="Virtual site code has not yet been refactored for version 0.11.0"
+# )
 class TestVirtualSiteGenerator:
     def test_apply_virtual_sites(self, vsite_collection):
         molecule = smiles_to_molecule("N")
 
-        molecule, assigned_vsite_keys = VirtualSiteGenerator._apply_virtual_sites(
+        smirnoff_virtual_site_collection = VirtualSiteGenerator._apply_virtual_sites(
             molecule, vsite_collection
         )
 
-        assert molecule.n_virtual_sites == 1
+        sites = smirnoff_virtual_site_collection.key_map
+        assert len(sites) == 1
 
-        orientations = molecule.virtual_sites[0].orientations
-        assert len(orientations) == 1
-
-        assert assigned_vsite_keys == {
-            orientations[0][0]: {
-                ("[#1:2][#7:1]([#1:3])[#1:4]", "TrivalentLonePair", "EP"): [
-                    (0, 1, 2, 3)
-                ]
-            }
-        }
+        vsite_key, potential_key = list(sites.items())[0]
+        assert vsite_key.orientation_atom_indices == (0, 1, 2, 3)
+        assert potential_key.id == "[#1:2][#7:1]([#1:3])[#1:4] EP once"
+        assert vsite_key.type == "TrivalentLonePair"
 
     def test_build_charge_array(self, vsite_collection):
         charge_values, charge_keys = VirtualSiteGenerator._build_charge_increment_array(

--- a/openff/recharge/tests/optimize/test_optimize.py
+++ b/openff/recharge/tests/optimize/test_optimize.py
@@ -294,9 +294,6 @@ def test_term_evaluate_atom_charge_and_vsite(
     assert numpy.isclose(expected_loss, output_loss)
 
 
-@pytest.mark.skip(
-    reason="Virtual site code has not yet been refactored for version 0.11.0"
-)
 @pytest.mark.parametrize("objective_class", [ESPObjective, ElectricFieldObjective])
 @pytest.mark.parametrize("backend", backends)
 def test_combine_terms(objective_class, backend, hcl_parameters):
@@ -402,9 +399,6 @@ def test_compute_bcc_charge_terms():
     assert numpy.allclose(fixed_charges, numpy.array([[0], [2], [-2], [0]]))
 
 
-@pytest.mark.skip(
-    reason="Virtual site code has not yet been refactored for version 0.11.0"
-)
 def test_compute_vsite_charge_terms():
     molecule = Molecule.from_mapped_smiles("[H:1][C:2]#[C:3][F:4]")
 
@@ -452,9 +446,6 @@ def test_compute_vsite_charge_terms():
     )
 
 
-@pytest.mark.skip(
-    reason="Virtual site code has not yet been refactored for version 0.11.0"
-)
 def test_compute_vsite_coord_terms():
     molecule = smiles_to_molecule("FC=O")
 
@@ -523,9 +514,6 @@ def test_compute_vsite_coord_terms():
     assert local_frame.shape == (4, 2, 3)
 
 
-@pytest.mark.skip(
-    reason="Virtual site code has not yet been refactored for version 0.11.0"
-)
 def test_compute_esp_objective_terms(hcl_esp_record, hcl_parameters):
     bcc_collection, vsite_collection = hcl_parameters
 
@@ -592,9 +580,6 @@ def test_compute_esp_objective_terms(hcl_esp_record, hcl_parameters):
     )
 
 
-@pytest.mark.skip(
-    reason="Virtual site code has not yet been refactored for version 0.11.0"
-)
 def test_compute_esp_objective_terms_no_v_site(hcl_esp_record, hcl_parameters):
     """Test that ESP objective can still be built when no v-sites match the records."""
 
@@ -664,9 +649,6 @@ def test_compute_esp_objective_terms_no_v_site(hcl_esp_record, hcl_parameters):
     assert numpy.isclose(loss, loss_no_v_site)
 
 
-@pytest.mark.skip(
-    reason="Virtual site code has not yet been refactored for version 0.11.0"
-)
 def test_compute_field_objective_terms(hcl_esp_record, hcl_parameters):
     bcc_collection, vsite_collection = hcl_parameters
 


### PR DESCRIPTION
## Description
Fixes #136
Updates virtual site code to interact with OpenFF Interchange, as per post 0.11 OpenFF toolkit.

## Todos
- [x] updated code
- [x] unskipped tests

## Notes
A lot of OpenFF recharge bookkeeping depends on the following structure for a key: `(parameter.smirks, parameter.type, parameter.name)`. I kept it in this refactor to get it running asap, but it's somewhat fragile -- the smirks is stored in a `PotentialKey` in interchange as part of `PotentialKey.id`. It's also likely to change in the future if the `TODO` is anything to go by. Just something to keep an eye out for.
https://github.com/openforcefield/openff-interchange/blob/main/openff/interchange/smirnoff/_virtual_sites.py#L107-L113
```
                    # TODO: Better way of specifying unique parameters
                    potential_key = PotentialKey(
                        id=" ".join(
                            [parameter.smirks, parameter.name, parameter.match],
                        ),
                        associated_handler="VirtualSites",
                    )
```
