### PR TITLE
Optionally generate Psi4 ESPs with multiple threads

### DIFF
--- a/openff/recharge/_tests/esp/test_psi4.py
+++ b/openff/recharge/_tests/esp/test_psi4.py
@@ -217,8 +217,11 @@ def test_generate_input_pcm():
     assert expected_output == input_contents
 
 
-@pytest.mark.parametrize("enable_pcm, minimize", [(False, True), (True, False)])
-def test_generate(enable_pcm, minimize):
+@pytest.mark.parametrize(
+    "enable_pcm, minimize, n_threads",
+    [(False, True, 1), (True, False, 1), (True, False, 2)],
+)
+def test_generate(enable_pcm, minimize, n_threads):
     """Perform a test run of Psi4."""
     pytest.importorskip("psi4")
 
@@ -245,7 +248,8 @@ def test_generate(enable_pcm, minimize):
     )
 
     output_conformer, grid, esp, electric_field = Psi4ESPGenerator.generate(
-        molecule, input_conformer, settings, minimize=minimize
+        molecule, input_conformer, settings, minimize=minimize,
+        n_threads=n_threads,
     )
 
     assert grid.shape[0] > 0

--- a/openff/recharge/_tests/esp/test_psi4.py
+++ b/openff/recharge/_tests/esp/test_psi4.py
@@ -248,7 +248,10 @@ def test_generate(enable_pcm, minimize, n_threads):
     )
 
     output_conformer, grid, esp, electric_field = Psi4ESPGenerator.generate(
-        molecule, input_conformer, settings, minimize=minimize,
+        molecule,
+        input_conformer,
+        settings,
+        minimize=minimize,
         n_threads=n_threads,
     )
 

--- a/openff/recharge/esp/_esp.py
+++ b/openff/recharge/esp/_esp.py
@@ -111,6 +111,7 @@ class ESPGenerator(abc.ABC):
         minimize: bool,
         compute_esp: bool,
         compute_field: bool,
+        n_threads: int,
     ) -> Tuple[unit.Quantity, Optional[unit.Quantity], Optional[unit.Quantity]]:
         """The implementation of the public ``generate`` function which
         should return the ESP for the provided conformer.
@@ -155,6 +156,7 @@ class ESPGenerator(abc.ABC):
         minimize: bool = False,
         compute_esp: bool = True,
         compute_field: bool = True,
+        n_threads: int = 1,
     ) -> Tuple[
         unit.Quantity, unit.Quantity, Optional[unit.Quantity], Optional[unit.Quantity]
     ]:
@@ -202,6 +204,7 @@ class ESPGenerator(abc.ABC):
             minimize,
             compute_esp,
             compute_field,
+            n_threads,
         )
 
         return conformer, grid, esp, electric_field

--- a/openff/recharge/esp/psi4.py
+++ b/openff/recharge/esp/psi4.py
@@ -131,6 +131,7 @@ class Psi4ESPGenerator(ESPGenerator):
         minimize: bool,
         compute_esp: bool,
         compute_field: bool,
+        n_threads: int,
     ) -> Tuple[unit.Quantity, Optional[unit.Quantity], Optional[unit.Quantity]]:
         # Perform the calculation in a temporary directory
         with temporary_cd(directory):
@@ -148,7 +149,7 @@ class Psi4ESPGenerator(ESPGenerator):
 
             # Attempt to run the calculation
             psi4_process = subprocess.Popen(
-                ["psi4", "input.dat", "output.dat"],
+                ["psi4", "--nthread", str(n_threads), "input.dat", "output.dat"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )


### PR DESCRIPTION
## Description
#146

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Expose `n_threads` argument that is passed to Psi4 ESP call
  - [x] Add unit test ensuring `n_threads=2` does not cause errors
  - [x] Roughly benchmark that using multiple threads speeds up ESP calculations

## Questions
- [ ] Question1

## Status
- [x] Ready to go
