### PR TITLE
Fix Psi4 always minimize with SCF

### DIFF
--- a/openff/recharge/data/psi4/input.dat
+++ b/openff/recharge/data/psi4/input.dat
@@ -44,7 +44,7 @@ pcm = {
 
 {%- if minimize %}
 
-optimize('scf')
+optimize('{{ method }}')
 {%- endif %}
 
 E,wfn = prop('{%- if spin == 2 %}u{% endif %}{{ method }}', properties = {{ properties }}, return_wfn=True)


### PR DESCRIPTION
## Description

This PR fixes a bug whereby Psi4 always minimized with HF, even if a different method is used.

## Status
- [X] Ready to go
