### PR TITLE
set psi4 memory

### DIFF
--- a/openff/recharge/data/psi4/input.dat
+++ b/openff/recharge/data/psi4/input.dat
@@ -1,3 +1,5 @@
+memory {{ memory_limit_gb }} GB
+
 molecule mol {
   noreorient
   nocom

--- a/openff/recharge/esp/_esp.py
+++ b/openff/recharge/esp/_esp.py
@@ -158,7 +158,7 @@ class ESPGenerator(abc.ABC):
         compute_esp: bool = True,
         compute_field: bool = True,
         n_threads: int = 1,
-        memory_limit_gb: int=1,
+        memory_limit_gb: int = 1,
     ) -> tuple[Quantity, Quantity, Quantity | None, Quantity | None]:
         """Generate the electrostatic potential (ESP) on a grid defined by
         a provided set of settings.

--- a/openff/recharge/esp/_esp.py
+++ b/openff/recharge/esp/_esp.py
@@ -112,6 +112,7 @@ class ESPGenerator(abc.ABC):
         compute_esp: bool,
         compute_field: bool,
         n_threads: int,
+        memory_limit_gb: int,
     ) -> tuple[Quantity, Quantity | None, Quantity | None]:
         """The implementation of the public ``generate`` function which
         should return the ESP for the provided conformer.
@@ -157,6 +158,7 @@ class ESPGenerator(abc.ABC):
         compute_esp: bool = True,
         compute_field: bool = True,
         n_threads: int = 1,
+        memory_limit_gb: int=1,
     ) -> tuple[Quantity, Quantity, Quantity | None, Quantity | None]:
         """Generate the electrostatic potential (ESP) on a grid defined by
         a provided set of settings.
@@ -203,6 +205,7 @@ class ESPGenerator(abc.ABC):
             compute_esp,
             compute_field,
             n_threads,
+            memory_limit_gb,
         )
 
         return conformer, grid, esp, electric_field

--- a/openff/recharge/esp/psi4.py
+++ b/openff/recharge/esp/psi4.py
@@ -141,7 +141,13 @@ class Psi4ESPGenerator(ESPGenerator):
         with temporary_cd(directory):
             # Store the input file.
             input_contents = cls._generate_input(
-                molecule, conformer, settings, minimize, compute_esp, compute_field, memory_limit_gb
+                molecule,
+                conformer,
+                settings,
+                minimize,
+                compute_esp,
+                compute_field,
+                memory_limit_gb,
             )
 
             with open("input.dat", "w") as file:

--- a/openff/recharge/esp/psi4.py
+++ b/openff/recharge/esp/psi4.py
@@ -31,6 +31,7 @@ class Psi4ESPGenerator(ESPGenerator):
         minimize: bool,
         compute_esp: bool,
         compute_field: bool,
+        memory_limit_gb: int,
     ) -> str:
         """Generate the input files for Psi4.
 
@@ -102,6 +103,7 @@ class Psi4ESPGenerator(ESPGenerator):
             "dft_settings": settings.psi4_dft_grid_settings.value,
             "minimize": minimize,
             "properties": str(properties),
+            "memory_limit_gb": memory_limit_gb,
         }
 
         if enable_pcm:
@@ -133,12 +135,13 @@ class Psi4ESPGenerator(ESPGenerator):
         compute_esp: bool,
         compute_field: bool,
         n_threads: int,
+        memory_limit_gb: int,
     ) -> tuple[Quantity, Quantity | None, Quantity | None]:
         # Perform the calculation in a temporary directory
         with temporary_cd(directory):
             # Store the input file.
             input_contents = cls._generate_input(
-                molecule, conformer, settings, minimize, compute_esp, compute_field
+                molecule, conformer, settings, minimize, compute_esp, compute_field, memory_limit_gb
             )
 
             with open("input.dat", "w") as file:


### PR DESCRIPTION
## Description

will fix #168 
enables setting the psi4 memory limit with running resp.

This works for my purposes. I can now run resp on larger molecules without psi4 complaining about hitting the memory limits. 

Happy to change syntax/ implementation to whatever you prefer

## Status
- [x] Ready to go

