### PR TITLE
Add memory specification to file

### DIFF
--- a/openff/recharge/_tests/esp/test_psi4.py
+++ b/openff/recharge/_tests/esp/test_psi4.py
@@ -177,6 +177,68 @@ def test_generate_input_pcm():
 
     expected_output = "\n".join(
         [
+            "memory 256 MB",
+            "",
+            "molecule mol {",
+            "  noreorient",
+            "  nocom",
+            "  -1 1",
+            "  Cl  1.000000000  0.000000000  0.000000000",
+            "}",
+            "",
+            "set {",
+            "  basis 6-31g*",
+            "",
+            "  pcm true",
+            "  pcm_scf_type total",
+            "}",
+            "pcm = {",
+            "  Units = Angstrom",
+            "  Medium {",
+            "  SolverType = CPCM",
+            "  Solvent = Water",
+            "  }",
+            "",
+            "  Cavity {",
+            "  RadiiSet = Bondi",
+            "  Type = GePol",
+            "  Scaling = True",
+            "  Area = 0.3",
+            "  Mode = Implicit",
+            "  }",
+            "}",
+            "",
+            "E,wfn = prop('hf', properties = ['GRID_ESP', 'GRID_FIELD'], "
+            "return_wfn=True)",
+            "mol.save_xyz_file('final-geometry.xyz',1)",
+        ]
+    )
+
+    assert expected_output == input_contents
+
+def test_generate_input_pcm_memory():
+    """Test that the correct input is generated from the
+    jinja template."""
+    pytest.importorskip("psi4")
+
+    # Define the settings to use.
+    settings = ESPSettings(
+        pcm_settings=PCMSettings(), grid_settings=LatticeGridSettings()
+    )
+
+    # Create a closed shell molecule.
+    molecule = smiles_to_molecule("[Cl-]")
+    conformer = numpy.array([[0.1, 0.0, 0.0]]) * unit.nanometer
+
+    input_contents = Psi4ESPGenerator._generate_input(
+        molecule, conformer, settings, False, True, True,
+        memory=2 * unit.gigabytes
+    )
+
+    expected_output = "\n".join(
+        [
+            "memory 2 GB",
+            "",
             "molecule mol {",
             "  noreorient",
             "  nocom",

--- a/openff/recharge/_tests/esp/test_psi4.py
+++ b/openff/recharge/_tests/esp/test_psi4.py
@@ -177,7 +177,7 @@ def test_generate_input_pcm():
 
     expected_output = "\n".join(
         [
-            "memory 256 MB",
+            "memory 500 MiB",
             "",
             "molecule mol {",
             "  noreorient",

--- a/openff/recharge/_tests/esp/test_psi4.py
+++ b/openff/recharge/_tests/esp/test_psi4.py
@@ -216,6 +216,7 @@ def test_generate_input_pcm():
 
     assert expected_output == input_contents
 
+
 def test_generate_input_pcm_memory():
     """Test that the correct input is generated from the
     jinja template."""
@@ -231,8 +232,7 @@ def test_generate_input_pcm_memory():
     conformer = numpy.array([[0.1, 0.0, 0.0]]) * unit.nanometer
 
     input_contents = Psi4ESPGenerator._generate_input(
-        molecule, conformer, settings, False, True, True,
-        memory=2 * unit.gigabytes
+        molecule, conformer, settings, False, True, True, memory=2 * unit.gigabytes
     )
 
     expected_output = "\n".join(

--- a/openff/recharge/_tests/esp/test_psi4.py
+++ b/openff/recharge/_tests/esp/test_psi4.py
@@ -39,6 +39,8 @@ def test_generate_input_base(compute_esp, compute_field, expected_properties):
 
     expected_output = "\n".join(
         [
+            "memory 500 MiB",
+            "",
             "molecule mol {",
             "  noreorient",
             "  nocom",
@@ -68,6 +70,8 @@ def test_generate_input_base(compute_esp, compute_field, expected_properties):
 
     expected_output = "\n".join(
         [
+            "memory 500 MiB",
+            "",
             "molecule mol {",
             "  noreorient",
             "  nocom",
@@ -136,6 +140,8 @@ def test_generate_input_dft_settings(
 
     expected_output = "\n".join(
         [
+            "memory 500 MiB",
+            "",
             "molecule mol {",
             "  noreorient",
             "  nocom",

--- a/openff/recharge/data/psi4/input.dat
+++ b/openff/recharge/data/psi4/input.dat
@@ -1,3 +1,5 @@
+memory {{ memory }}
+
 molecule mol {
   noreorient
   nocom

--- a/openff/recharge/esp/_esp.py
+++ b/openff/recharge/esp/_esp.py
@@ -207,7 +207,7 @@ class ESPGenerator(abc.ABC):
             compute_esp,
             compute_field,
             n_threads,
-            memory=memory
+            memory=memory,
         )
 
         return conformer, grid, esp, electric_field

--- a/openff/recharge/esp/_esp.py
+++ b/openff/recharge/esp/_esp.py
@@ -3,7 +3,7 @@ import os
 from enum import Enum
 from typing import TYPE_CHECKING, Literal
 
-from openff.units import Quantity
+from openff.units import unit, Quantity
 from openff.recharge._pydantic import BaseModel, Field
 
 from openff.recharge.grids import GridGenerator, GridSettingsType
@@ -157,6 +157,7 @@ class ESPGenerator(abc.ABC):
         compute_esp: bool = True,
         compute_field: bool = True,
         n_threads: int = 1,
+        memory: Quantity = 500 * unit.mebibytes,
     ) -> tuple[Quantity, Quantity, Quantity | None, Quantity | None]:
         """Generate the electrostatic potential (ESP) on a grid defined by
         a provided set of settings.
@@ -179,6 +180,9 @@ class ESPGenerator(abc.ABC):
             Whether to compute the ESP at each grid point.
         compute_field
             Whether to compute the field at each grid point.
+        memory
+            The memory to make available to Psi4 for computation
+
 
         Returns
         -------
@@ -203,6 +207,7 @@ class ESPGenerator(abc.ABC):
             compute_esp,
             compute_field,
             n_threads,
+            memory=memory
         )
 
         return conformer, grid, esp, electric_field

--- a/openff/recharge/esp/_esp.py
+++ b/openff/recharge/esp/_esp.py
@@ -112,6 +112,7 @@ class ESPGenerator(abc.ABC):
         compute_esp: bool,
         compute_field: bool,
         n_threads: int,
+        memory: Quantity = 500 * unit.mebibytes,
     ) -> tuple[Quantity, Quantity | None, Quantity | None]:
         """The implementation of the public ``generate`` function which
         should return the ESP for the provided conformer.
@@ -136,6 +137,8 @@ class ESPGenerator(abc.ABC):
             Whether to compute the ESP at each grid point.
         compute_field
             Whether to compute the field at each grid point.
+        memory
+            The memory to make available for computation
 
         Returns
         -------

--- a/openff/recharge/esp/_esp.py
+++ b/openff/recharge/esp/_esp.py
@@ -138,7 +138,7 @@ class ESPGenerator(abc.ABC):
         compute_field
             Whether to compute the field at each grid point.
         memory
-            The memory to make available for computation
+            The memory to make available for computation_
 
         Returns
         -------
@@ -184,7 +184,9 @@ class ESPGenerator(abc.ABC):
         compute_field
             Whether to compute the field at each grid point.
         memory
-            The memory to make available to Psi4 for computation
+            The memory to make available to Psi4 for computation.
+            Default is 500 MiB, as is the default in Psi4
+            (see psicode.org/psi4manual/master/psithoninput.html#memory-specification).
 
 
         Returns

--- a/openff/recharge/esp/psi4.py
+++ b/openff/recharge/esp/psi4.py
@@ -31,7 +31,7 @@ class Psi4ESPGenerator(ESPGenerator):
         minimize: bool,
         compute_esp: bool,
         compute_field: bool,
-        memory: Quantity = 256 * unit.megabytes,
+        memory: Quantity = 500 * unit.mebibytes,
     ) -> str:
         """Generate the input files for Psi4.
 
@@ -137,7 +137,7 @@ class Psi4ESPGenerator(ESPGenerator):
         compute_esp: bool,
         compute_field: bool,
         n_threads: int,
-        memory: Quantity = 256 * unit.megabytes,
+        memory: Quantity = 500 * unit.mebibytes,
     ) -> tuple[Quantity, Quantity | None, Quantity | None]:
         # Perform the calculation in a temporary directory
         with temporary_cd(directory):

--- a/openff/recharge/esp/psi4.py
+++ b/openff/recharge/esp/psi4.py
@@ -31,6 +31,7 @@ class Psi4ESPGenerator(ESPGenerator):
         minimize: bool,
         compute_esp: bool,
         compute_field: bool,
+        memory: Quantity = 256 * unit.megabytes
     ) -> str:
         """Generate the input files for Psi4.
 
@@ -49,6 +50,8 @@ class Psi4ESPGenerator(ESPGenerator):
             Whether to compute the ESP at each grid point.
         compute_field
             Whether to compute the field at each grid point.
+        memory
+            The memory to make available to Psi4 for computation
 
         Returns
         -------
@@ -102,6 +105,7 @@ class Psi4ESPGenerator(ESPGenerator):
             "dft_settings": settings.psi4_dft_grid_settings.value,
             "minimize": minimize,
             "properties": str(properties),
+            "memory": f"{memory:~P}"
         }
 
         if enable_pcm:
@@ -133,12 +137,14 @@ class Psi4ESPGenerator(ESPGenerator):
         compute_esp: bool,
         compute_field: bool,
         n_threads: int,
+        memory: Quantity = 256 * unit.megabytes,
     ) -> tuple[Quantity, Quantity | None, Quantity | None]:
         # Perform the calculation in a temporary directory
         with temporary_cd(directory):
             # Store the input file.
             input_contents = cls._generate_input(
-                molecule, conformer, settings, minimize, compute_esp, compute_field
+                molecule, conformer, settings, minimize, compute_esp, compute_field,
+                memory=memory,
             )
 
             with open("input.dat", "w") as file:

--- a/openff/recharge/esp/psi4.py
+++ b/openff/recharge/esp/psi4.py
@@ -31,7 +31,7 @@ class Psi4ESPGenerator(ESPGenerator):
         minimize: bool,
         compute_esp: bool,
         compute_field: bool,
-        memory: Quantity = 256 * unit.megabytes
+        memory: Quantity = 256 * unit.megabytes,
     ) -> str:
         """Generate the input files for Psi4.
 
@@ -105,7 +105,7 @@ class Psi4ESPGenerator(ESPGenerator):
             "dft_settings": settings.psi4_dft_grid_settings.value,
             "minimize": minimize,
             "properties": str(properties),
-            "memory": f"{memory:~P}"
+            "memory": f"{memory:~P}",
         }
 
         if enable_pcm:
@@ -143,7 +143,12 @@ class Psi4ESPGenerator(ESPGenerator):
         with temporary_cd(directory):
             # Store the input file.
             input_contents = cls._generate_input(
-                molecule, conformer, settings, minimize, compute_esp, compute_field,
+                molecule,
+                conformer,
+                settings,
+                minimize,
+                compute_esp,
+                compute_field,
                 memory=memory,
             )
 


### PR DESCRIPTION
## Description

Relates to #168 , #169 

This sets the memory usage in the input file. The other way is to use commandline (`psi4 --memory`), which I decided not to go with because:
* it's more difficult to test
* it makes it easier to theoretically pass around input files as the memory requirements are encoded
